### PR TITLE
Fixed enum usage and format for the same format as other fty projects

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,83 +1,91 @@
----
-Language:        Cpp
-# BasedOnStyle:  LLVM
-AccessModifierOffset: -2
-AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
+IncludeCategories:
+  - Regex:           '^<'
+    Priority:        10
+  - Regex:           '^"'
+    Priority:        1
+
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
 AlignEscapedNewlinesLeft: false
 AlignOperands:   true
 AlignTrailingComments: true
+AlignConsecutiveMacros: true
 AllowAllParametersOfDeclarationOnNextLine: true
+AccessModifierOffset: -4
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: false
+AllowAllConstructorInitializersOnNextLine: true
+
+AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: true
-BinPackArguments: false
+#AlwaysBreakAfterReturnType: All
+
+BinPackArguments: true
 BinPackParameters: false
-BraceWrapping:
-  AfterClass:      true
-  AfterControlStatement: true
-  AfterEnum:       true
-  AfterFunction:   true
-  AfterNamespace:  true
-  AfterStruct:     true
-  AfterUnion:      true
-  BeforeCatch:     true
-  BeforeElse:      true
-  IndentBraces:    false
 BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Custom
+BreakBeforeBraces: Attach
 BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: true
-ColumnLimit:     0
+ColumnLimit: 140
+BreakConstructorInitializers: BeforeComma
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
 CommentPragmas:  '^ IWYU pragma:'
-ConstructorInitializerIndentWidth: 2
-ContinuationIndentWidth: 2
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterEnum: true
+  AfterStruct: true
+  AfterClass: true
+  AfterControlStatement: false
+  AfterFunction: true
+  AfterNamespace: false
+  BeforeElse: false
+
+
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
+
 DerivePointerAlignment: false
-DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
-ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
-IncludeCategories:
-  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
-    Priority:        2
-  - Regex:           '^(<|"(gtest|isl|json)/)'
-    Priority:        3
-  - Regex:           '.*'
-    Priority:        1
-IndentCaseLabels: true
-IndentWidth:     2
+IndentCaseLabels: false
+IndentWidth:     4
 IndentWrappedFunctionNames: false
+IncludeBlocks: Merge
 KeepEmptyLinesAtTheStartOfBlocks: true
-MacroBlockBegin: ''
-MacroBlockEnd:   ''
-MaxEmptyLinesToKeep: 1
-NamespaceIndentation: All
-PenaltyBreakBeforeFirstCallParameter: 19
+
+Language: Cpp
+
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: Inner
+CompactNamespaces: true
+
+PenaltyBreakBeforeFirstCallParameter: 9999999
 PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
+PenaltyBreakFirstLessLess: 9999999
 PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyReturnTypeOnItsOwnLine: 9999999
+
 PointerAlignment: Left
-ReflowComments:  true
-SortIncludes:    true
+
 SpaceAfterCStyleCast: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles:  false
-SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        c++17
-TabWidth:        2
+SpaceBeforeCtorInitializerColon: false
+
+Standard:        Cpp11
+TabWidth:        4
 UseTab:          Never
+IndentCaseLabels: true
+
+AllowShortLambdasOnASingleLine: None

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,11 +12,11 @@ find_package(fty-cmake PATHS ${CMAKE_BINARY_DIR}/fty-cmake REQUIRED)
 
 ## TO BE MOVED IN FTY-CMAKE
 macro(relative_option parent_option new_option_name text)
-  if (${parent_option})
-    option(${new_option_name} ${text} ON)
-  else()
-    option(${new_option_name} ${text} OFF)
-  endif()
+    if (${parent_option})
+        option(${new_option_name} ${text} ON)
+    else()
+        option(${new_option_name} ${text} OFF)
+    endif()
 endmacro()
 
 option(                            BUILD_ALL                   "Build all addons"                  ON)
@@ -33,15 +33,15 @@ add_subdirectory(common)
 # Addons
 
 if(BUILD_AMQP)
-  add_subdirectory(amqp)
+    add_subdirectory(amqp)
 endif()
 
 if(BUILD_MQTT)
-  add_subdirectory(mqtt)
+    add_subdirectory(mqtt)
 endif()
 
 # Samples
 if(BUILD_SAMPLES)
-  set(SAMPLE_DTO_LIB_NAME fty-common-messagebus2-sample-dto)
-  add_subdirectory(samples)
+    set(SAMPLE_DTO_LIB_NAME fty-common-messagebus2-sample-dto)
+    add_subdirectory(samples)
 endif()

--- a/amqp/CMakeLists.txt
+++ b/amqp/CMakeLists.txt
@@ -9,29 +9,25 @@ find_package(ProtonCpp REQUIRED)
 ##############################################################################################################
 
 etn_target(shared ${PROJECT_NAME} PUBLIC
-  SOURCES
-    src/*.cpp
-    src/*.h
-  PUBLIC_INCLUDE_DIR
-    public_include
-  PUBLIC_HEADERS
-    fty/messagebus/amqp/MessageBusAmqp.h
-  USES_PUBLIC
-    fty-common-messagebus2
-  USES_PRIVATE
-    fty-common-messagebus-utils
-    fty_common_logging
-    Proton::cpp
-  FLAGS
-    "-fmax-errors=1"
+    SOURCES
+        src/*.cpp
+        src/*.h
+    PUBLIC_INCLUDE_DIR
+        public_include
+    PUBLIC_HEADERS
+        fty/messagebus/amqp/MessageBusAmqp.h
+    USES_PUBLIC
+        fty-common-messagebus2
+    USES_PRIVATE
+        fty-common-messagebus-utils
+        fty_common_logging
+        Proton::cpp
 )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR})
 
 ## Tests
-if(BUILD_TESTING)
-  etn_test_target(${PROJECT_NAME}
+etn_test_target(${PROJECT_NAME}
     SOURCES
-      tests/*.cpp
+        tests/*.cpp
 )
-endif()

--- a/amqp/public_include/fty/messagebus/amqp/MessageBusAmqp.h
+++ b/amqp/public_include/fty/messagebus/amqp/MessageBusAmqp.h
@@ -23,36 +23,36 @@
 #include <fty/messagebus/MessageBus.h>
 #include <fty/messagebus/utils.h>
 
-namespace fty::messagebus::amqp
+namespace fty::messagebus::amqp {
+
+// Default amqp end point
+static auto constexpr DEFAULT_ENDPOINT{"amqp://127.0.0.1:5672"};
+
+static auto constexpr BUS_IDENTITY{"AMQP"};
+static const std::string TOPIC_PREFIX = "topic://";
+static const std::string QUEUE_PREFIX = "queue://";
+
+class MsgBusAmqp;
+
+class MessageBusAmqp final : public fty::messagebus::MessageBus
 {
-  // Default amqp end point
-  static auto constexpr DEFAULT_ENDPOINT{"amqp://127.0.0.1:5672"};
-
-  static auto constexpr BUS_IDENTITY{"AMQP"};
-  static const std::string TOPIC_PREFIX = "topic://";
-  static const std::string QUEUE_PREFIX = "queue://";
-
-  class MsgBusAmqp;
-
-  class MessageBusAmqp final : public fty::messagebus::MessageBus
-  {
-  public:
-    MessageBusAmqp(const ClientName& clientName = utils::getClientId("MessageBusAmqp"),
-                   const Endpoint& endpoint = DEFAULT_ENDPOINT);
+public:
+    MessageBusAmqp(const ClientName& clientName = utils::getClientId("MessageBusAmqp"), const Endpoint& endpoint = DEFAULT_ENDPOINT);
 
     ~MessageBusAmqp() = default;
 
-    [[nodiscard]] fty::Expected<void> connect() noexcept override;
-    [[nodiscard]] fty::Expected<void> send(const Message& msg) noexcept override;
-    [[nodiscard]] fty::Expected<void> receive(const Address& address, MessageListener&& func, const std::string& filter = {}) noexcept override;
-    [[nodiscard]] fty::Expected<void> unreceive(const Address& address) noexcept override;
-    [[nodiscard]] fty::Expected<Message> request(const Message& msg, int timeOut) noexcept override;
+    [[nodiscard]] fty::Expected<void, ComState>      connect() noexcept override;
+    [[nodiscard]] fty::Expected<void, DeliveryState> send(const Message& msg) noexcept override;
+    [[nodiscard]] fty::Expected<void, DeliveryState> receive(
+        const Address& address, MessageListener&& func, const std::string& filter = {}) noexcept override;
+    [[nodiscard]] fty::Expected<void, DeliveryState>    unreceive(const Address& address) noexcept override;
+    [[nodiscard]] fty::Expected<Message, DeliveryState> request(const Message& msg, int timeOut) noexcept override;
 
     [[nodiscard]] const ClientName& clientName() const noexcept override;
-    [[nodiscard]] const Identity& identity() const noexcept override;
+    [[nodiscard]] const Identity&   identity() const noexcept override;
 
-  private:
+private:
     std::shared_ptr<MsgBusAmqp> m_busAmqp;
-  };
+};
 
 } // namespace fty::messagebus::amqp

--- a/amqp/src/AmqpClient.cpp
+++ b/amqp/src/AmqpClient.cpp
@@ -18,296 +18,252 @@
 */
 
 #include "AmqpClient.h"
-
+#include <fty_log.h>
 #include <proton/connection_options.hpp>
 #include <proton/reconnect_options.hpp>
 #include <proton/tracker.hpp>
 #include <proton/work_queue.hpp>
 
-#include <fty_log.h>
-
-namespace
+namespace {
+proton::reconnect_options reconnectOpts()
 {
-  proton::reconnect_options reconnectOpts()
-  {
     proton::reconnect_options reconnectOption;
     reconnectOption.delay(proton::duration::SECOND);
     reconnectOption.max_delay(proton::duration::MINUTE);
     reconnectOption.max_attempts(10);
     reconnectOption.delay_multiplier(5);
     return reconnectOption;
-  }
+}
 
-  proton::connection_options connectOpts()
-  {
+proton::connection_options connectOpts()
+{
     return proton::connection_options();
-  }
+}
 
 } // namespace
 
-namespace fty::messagebus::amqp
-{
-  using namespace fty::messagebus;
-  using MessageListener = fty::messagebus::MessageListener;
+namespace fty::messagebus::amqp {
 
-  static auto constexpr TIMEOUT = std::chrono::seconds(5);
+using MessageListener = fty::messagebus::MessageListener;
 
-  AmqpClient::AmqpClient(const Endpoint& url)
+static auto constexpr TIMEOUT = std::chrono::seconds(5);
+
+AmqpClient::AmqpClient(const Endpoint& url)
     : m_url(url)
-  {
+{
     m_connectFuture = m_connectPromise.get_future();
-  }
+}
 
-  AmqpClient::~AmqpClient()
-  {
+AmqpClient::~AmqpClient()
+{
     close();
-  }
+}
 
-  void AmqpClient::on_container_start(proton::container& container)
-  {
-    try
-    {
-      container.connect(m_url, connectOpts().reconnect(reconnectOpts()));
+void AmqpClient::on_container_start(proton::container& container)
+{
+    try {
+        container.connect(m_url, connectOpts().reconnect(reconnectOpts()));
+    } catch (const std::exception& e) {
+        logError("Exception {}", e.what());
+        m_connectPromise.set_value(ComState::ConnectFailed);
     }
-    catch (const std::exception& e)
-    {
-      logError("Exception {}", e.what());
-      m_connectPromise.set_value(ComState::COM_STATE_CONNECT_FAILED);
-    }
-  }
+}
 
-  void AmqpClient::on_connection_open(proton::connection& connection)
-  {
+void AmqpClient::on_connection_open(proton::connection& connection)
+{
     m_connection = connection;
 
-    if (connection.reconnected())
-    {
-      logDebug("Reconnected on url: {}", m_url);
-      resetPromise();
+    if (connection.reconnected()) {
+        logDebug("Reconnected on url: {}", m_url);
+        resetPromise();
+    } else {
+        logDebug("Connected on url: {}", m_url);
     }
-    else
-    {
-      logDebug("Connected on url: {}", m_url);
-    }
-    m_connectPromise.set_value(ComState::COM_STATE_OK);
-  }
+    m_connectPromise.set_value(ComState::Ok);
+}
 
-  void AmqpClient::on_sender_open(proton::sender& sender)
-  {
+void AmqpClient::on_sender_open(proton::sender& sender)
+{
     logDebug("Sending message ...");
     sender.send(m_message);
     sender.connection().close();
     m_promiseSender.set_value();
     logDebug("Message sent");
-  }
+}
 
-  void AmqpClient::on_receiver_open(proton::receiver& receiver)
-  {
+void AmqpClient::on_receiver_open(proton::receiver& receiver)
+{
     logDebug("Waiting any message on target address: {}", receiver.source().address());
     // Record receiver to have the possibility to unreceive it (i.e. close it)
     m_receiver = receiver;
     m_promiseReceiver.set_value();
-  }
+}
 
-  void AmqpClient::on_error(const proton::error_condition& error)
-  {
+void AmqpClient::on_error(const proton::error_condition& error)
+{
     logError("Protocol error: {}", error.what());
-  }
+}
 
-  void AmqpClient::on_transport_error(proton::transport& transport)
-  {
+void AmqpClient::on_transport_error(proton::transport& transport)
+{
     logError("Transport error: {}", transport.error().what());
-    m_communicationState = ComState::COM_STATE_LOST;
-  }
+    m_communicationState = ComState::Lost;
+}
 
-  void AmqpClient::resetPromise()
-  {
+void AmqpClient::resetPromise()
+{
     logDebug("Reset all promise");
-    m_connectPromise = std::promise<fty::messagebus::ComState>();
-    m_connectFuture = m_connectPromise.get_future();
-    m_promiseSender = std::promise<void>();
+    m_connectPromise  = std::promise<fty::messagebus::ComState>();
+    m_connectFuture   = m_connectPromise.get_future();
+    m_promiseSender   = std::promise<void>();
     m_promiseReceiver = std::promise<void>();
-  }
+}
 
-  ComState AmqpClient::connected()
-  {
-    if ((m_communicationState == ComState::COM_STATE_UNKNOWN) || (m_communicationState == ComState::COM_STATE_LOST))
-    {
-      if (m_connectFuture.wait_for(TIMEOUT) != std::future_status::timeout)
-      {
-        try
-        {
-          m_communicationState = m_connectFuture.get();
+ComState AmqpClient::connected()
+{
+    if ((m_communicationState == ComState::Unknown) || (m_communicationState == ComState::Lost)) {
+        if (m_connectFuture.wait_for(TIMEOUT) != std::future_status::timeout) {
+            try {
+                m_communicationState = m_connectFuture.get();
+            } catch (const std::future_error& e) {
+                logError("Caught future error {}", e.what());
+            }
+        } else {
+            m_communicationState = ComState::ConnectFailed;
         }
-        catch (const std::future_error& e)
-        {
-          logError("Caught future error {}", e.what());
-        }
-      }
-      else
-      {
-        m_communicationState = ComState::COM_STATE_CONNECT_FAILED;
-      }
     }
     return m_communicationState;
-  }
+}
 
-  DeliveryState AmqpClient::send(const proton::message& msg)
-  {
-    auto deliveryState = DeliveryState::DELIVERY_STATE_REJECTED;
-    if (connected() == ComState::COM_STATE_OK)
-    {
-      m_promiseSender = std::promise<void>();
-      logDebug("Sending message to {} ...", msg.to());
-      m_message.clear();
-      m_message = msg;
+DeliveryState AmqpClient::send(const proton::message& msg)
+{
+    auto deliveryState = DeliveryState::Rejected;
+    if (connected() == ComState::Ok) {
+        m_promiseSender = std::promise<void>();
+        logDebug("Sending message to {} ...", msg.to());
+        m_message.clear();
+        m_message = msg;
 
-      m_connection.work_queue().add([=]() {
-        m_connection.open_sender(msg.to());
-      });
+        m_connection.work_queue().add([=]() {
+            m_connection.open_sender(msg.to());
+        });
 
-      // Wait the to know if the message has been sent or not
-      if (m_promiseSender.get_future().wait_for(TIMEOUT) != std::future_status::timeout)
-      {
-        deliveryState = DeliveryState::DELIVERY_STATE_ACCEPTED;
-      }
+        // Wait the to know if the message has been sent or not
+        if (m_promiseSender.get_future().wait_for(TIMEOUT) != std::future_status::timeout) {
+            deliveryState = DeliveryState::Accepted;
+        }
     }
     return deliveryState;
-  }
+}
 
-  DeliveryState AmqpClient::receive(const Address& address, const std::string& filter, MessageListener messageListener)
-  {
-    auto deliveryState = DeliveryState::DELIVERY_STATE_REJECTED;
-    if (connected() == ComState::COM_STATE_OK)
-    {
-      logDebug("Set receiver to wait message(s) from {} ...", address);
-      m_promiseReceiver = std::promise<void>();
+DeliveryState AmqpClient::receive(const Address& address, const std::string& filter, MessageListener messageListener)
+{
+    auto deliveryState = DeliveryState::Rejected;
+    if (connected() == ComState::Ok) {
+        logDebug("Set receiver to wait message(s) from {} ...", address);
+        m_promiseReceiver = std::promise<void>();
 
-      auto futureReceiver = m_promiseReceiver.get_future();
-      (!filter.empty()) ? setSubscriptions(filter, messageListener) : setSubscriptions(address, messageListener);
+        auto futureReceiver = m_promiseReceiver.get_future();
+        (!filter.empty()) ? setSubscriptions(filter, messageListener) : setSubscriptions(address, messageListener);
 
-      m_connection.work_queue().add([=]() {
-        m_connection.open_receiver(address, {});
-      });
+        m_connection.work_queue().add([=]() {
+            m_connection.open_receiver(address, {});
+        });
 
-      if (futureReceiver.wait_for(TIMEOUT) != std::future_status::timeout)
-      {
-        deliveryState = DeliveryState::DELIVERY_STATE_ACCEPTED;
-      }
+        if (futureReceiver.wait_for(TIMEOUT) != std::future_status::timeout) {
+            deliveryState = DeliveryState::Accepted;
+        }
     }
 
     return deliveryState;
-  }
+}
 
-  bool AmqpClient::tryConsumeMessageFor(std::shared_ptr<proton::message> resp, int timeoutInSeconds)
-  {
+bool AmqpClient::tryConsumeMessageFor(std::shared_ptr<proton::message> resp, int timeoutInSeconds)
+{
     logDebug("Checking answer for {} second(s)...", timeoutInSeconds);
 
     m_promiseSyncRequest = std::promise<proton::message>();
 
-    bool messageArrived = false;
+    bool messageArrived   = false;
     auto futureSynRequest = m_promiseSyncRequest.get_future();
-    if (futureSynRequest.wait_for(std::chrono::seconds(timeoutInSeconds)) != std::future_status::timeout)
-    {
-      try
-      {
-        *resp = std::move(futureSynRequest.get());
-        messageArrived = true;
-      }
-      catch (const std::future_error& e)
-      {
-        logError("Caught a future_error {}", e.what());
-      }
+    if (futureSynRequest.wait_for(std::chrono::seconds(timeoutInSeconds)) != std::future_status::timeout) {
+        try {
+            *resp          = futureSynRequest.get();
+            messageArrived = true;
+        } catch (const std::future_error& e) {
+            logError("Caught a future_error {}", e.what());
+        }
     }
     return messageArrived;
-  }
+}
 
-  void AmqpClient::on_message(proton::delivery& delivery, proton::message& msg)
-  {
+void AmqpClient::on_message(proton::delivery& delivery, proton::message& msg)
+{
     std::lock_guard<std::mutex> lock(m_lock);
     logDebug("Message arrived: {}", proton::to_string(msg));
     delivery.accept();
     Message amqpMsg(getMetaData(msg), msg.body().empty() ? std::string{} : proton::to_string(msg.body()));
 
-    if (m_connection)
-    {
-      if (!msg.correlation_id().empty() && msg.reply_to().empty())
-      {
-        if (auto it{m_subscriptions.find(proton::to_string(msg.correlation_id()))}; it != m_subscriptions.end())
-        {
-          // Asynchronous reply
-          logDebug("Asynchronous mode");
-          m_connection.work_queue().add(proton::make_work(it->second, amqpMsg));
+    if (m_connection) {
+        if (!msg.correlation_id().empty() && msg.reply_to().empty()) {
+            if (auto it{m_subscriptions.find(proton::to_string(msg.correlation_id()))}; it != m_subscriptions.end()) {
+                // Asynchronous reply
+                logDebug("Asynchronous mode");
+                m_connection.work_queue().add(proton::make_work(it->second, amqpMsg));
+            } else {
+                // Synchronous reply
+                logDebug("Synchronous mode");
+                m_promiseSyncRequest.set_value(msg);
+            }
+        } else {
+            if (auto it{m_subscriptions.find(msg.address())}; it != m_subscriptions.end()) {
+                // Any subscription
+                m_connection.work_queue().add(proton::make_work(it->second, amqpMsg));
+            } else {
+                logWarn("Message skipped for {}", msg.address());
+            }
         }
-        else
-        {
-          // Synchronous reply
-          logDebug("Synchronous mode");
-          m_promiseSyncRequest.set_value(msg);
-        }
-      }
-      else
-      {
-        if (auto it{m_subscriptions.find(msg.address())}; it != m_subscriptions.end())
-        {
-          // Any subscription
-          m_connection.work_queue().add(proton::make_work(it->second, amqpMsg));
-        }
-        else
-        {
-          logWarn("Message skipped for {}", msg.address());
-        }
-      }
+    } else {
+        // Connection object not set
+        logError("Nothing to do, connection object not set");
     }
-    else
-    {
-      // Connection object not set
-      logError("Nothing to do, connection object not set");
-    }
-  }
+}
 
-  void AmqpClient::setSubscriptions(const Address& address, MessageListener messageListener)
-  {
-    if (messageListener)
-    {
-      if (auto it{m_subscriptions.find(address)}; it == m_subscriptions.end())
-      {
-        auto ret = m_subscriptions.emplace(address, messageListener);
-        logTrace("Subscriptions emplaced: {} {}", address, ret.second ? "true" : "false");
-      }
-      else
-      {
-        logWarn("Set subscriptions skipped");
-      }
+void AmqpClient::setSubscriptions(const Address& address, MessageListener messageListener)
+{
+    if (messageListener) {
+        if (auto it{m_subscriptions.find(address)}; it == m_subscriptions.end()) {
+            auto ret = m_subscriptions.emplace(address, messageListener);
+            logTrace("Subscriptions emplaced: {} {}", address, ret.second ? "true" : "false");
+        } else {
+            logWarn("Set subscriptions skipped");
+        }
     }
-  }
+}
 
-  DeliveryState AmqpClient::unreceive()
-  {
+DeliveryState AmqpClient::unreceive()
+{
     std::lock_guard<std::mutex> lock(m_lock);
-    auto deliveryState = DeliveryState::DELIVERY_STATE_UNAVAILABLE;
-    if (m_receiver && m_receiver.active())
-    {
-      deliveryState = DeliveryState::DELIVERY_STATE_ACCEPTED;
-      m_receiver.close();
-      logDebug("Receiver Closed");
+    auto                        deliveryState = DeliveryState::Unavailable;
+    if (m_receiver && m_receiver.active()) {
+        deliveryState = DeliveryState::Accepted;
+        m_receiver.close();
+        logDebug("Receiver Closed");
     }
     return deliveryState;
-  }
+}
 
-  void AmqpClient::close()
-  {
+void AmqpClient::close()
+{
     std::lock_guard<std::mutex> lock(m_lock);
-    if (m_receiver && m_receiver.active())
-    {
-      m_receiver.close();
-      logDebug("Receiver Closed");
+    if (m_receiver && m_receiver.active()) {
+        m_receiver.close();
+        logDebug("Receiver Closed");
     }
-    if (m_connection && m_connection.active())
-    {
-      m_connection.close();
-      logDebug("Connection Closed");
+    if (m_connection && m_connection.active()) {
+        m_connection.close();
+        logDebug("Connection Closed");
     }
-  }
+}
 
 } // namespace fty::messagebus::amqp

--- a/amqp/src/AmqpClient.h
+++ b/amqp/src/AmqpClient.h
@@ -68,7 +68,7 @@ namespace fty::messagebus::amqp
     Endpoint m_url;
     SubScriptionListener m_subscriptions;
     // Default communication state
-    fty::messagebus::ComState m_communicationState = fty::messagebus::ComState::COM_STATE_UNKNOWN;
+    fty::messagebus::ComState m_communicationState = fty::messagebus::ComState::Unknown;
 
     // Proton object
     proton::connection m_connection;

--- a/amqp/src/MessageBusAmqp.cpp
+++ b/amqp/src/MessageBusAmqp.cpp
@@ -19,72 +19,67 @@
 
 #include "fty/messagebus/amqp/MessageBusAmqp.h"
 #include "MsgBusAmqp.h"
-
 #include <fty/expected.h>
 #include <fty/messagebus/MessageBusStatus.h>
 #include <fty_log.h>
-
 #include <memory>
 
-namespace fty::messagebus::amqp
-{
-  MessageBusAmqp::MessageBusAmqp(const ClientName& clientName,
-                                 const Endpoint& endpoint)
+namespace fty::messagebus::amqp {
+
+MessageBusAmqp::MessageBusAmqp(const ClientName& clientName, const Endpoint& endpoint)
     : MessageBus()
-  {
+{
     m_busAmqp = std::make_shared<MsgBusAmqp>(clientName, endpoint);
-  }
+}
 
-  fty::Expected<void> MessageBusAmqp::connect() noexcept
-  {
+fty::Expected<void, ComState> MessageBusAmqp::connect() noexcept
+{
     return m_busAmqp->connect();
-  }
+}
 
-  fty::Expected<void> MessageBusAmqp::send(const Message& msg) noexcept
-  {
-    if (!msg.isValidMessage())
-    {
-      return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_REJECTED));
+fty::Expected<void, DeliveryState> MessageBusAmqp::send(const Message& msg) noexcept
+{
+    if (!msg.isValidMessage()) {
+        return fty::unexpected(DeliveryState::Rejected);
     }
     return m_busAmqp->send(msg);
-  }
+}
 
-  fty::Expected<void> MessageBusAmqp::receive(const Address& address, MessageListener&& func, const std::string& filter) noexcept
-  {
+fty::Expected<void, DeliveryState> MessageBusAmqp::receive(
+    const Address& address, MessageListener&& func, const std::string& filter) noexcept
+{
     return m_busAmqp->receive(address, func, filter);
-  }
+}
 
-  fty::Expected<void> MessageBusAmqp::unreceive(const Address& address) noexcept
-  {
+fty::Expected<void, DeliveryState> MessageBusAmqp::unreceive(const Address& address) noexcept
+{
     return m_busAmqp->unreceive(address);
-  }
+}
 
-  fty::Expected<Message> MessageBusAmqp::request(const Message& msg, int timeOut) noexcept
-  {
-    //Sanity check
-    if (!msg.isValidMessage())
-    {
-      return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_REJECTED));
+fty::Expected<Message, DeliveryState> MessageBusAmqp::request(const Message& msg, int timeOut) noexcept
+{
+    // Sanity check
+    if (!msg.isValidMessage()) {
+        return fty::unexpected(DeliveryState::Rejected);
     }
-    if (!msg.needReply())
-    {
-      return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_REJECTED));
+    if (!msg.needReply()) {
+        return fty::unexpected(DeliveryState::Rejected);
     }
 
     // Send request
     return m_busAmqp->request(msg, timeOut);
-  }
+}
 
-  const std::string& MessageBusAmqp::clientName() const noexcept
-  {
+const std::string& MessageBusAmqp::clientName() const noexcept
+{
     return m_busAmqp->clientName();
-  }
+}
 
-  static const std::string g_identity(BUS_IDENTITY);
+static const std::string g_identity(BUS_IDENTITY);
 
-  const std::string& MessageBusAmqp::identity() const noexcept
-  {
+const std::string& MessageBusAmqp::identity() const noexcept
+{
     return g_identity;
-  }
+}
 
 } // namespace fty::messagebus::amqp

--- a/amqp/src/MsgBusAmqp.cpp
+++ b/amqp/src/MsgBusAmqp.cpp
@@ -19,179 +19,158 @@
 
 #include "MsgBusAmqp.h"
 #include "MsgBusAmqpUtils.h"
-
 #include <fty/messagebus/MessageBusStatus.h>
 #include <fty/messagebus/utils.h>
 #include <fty_log.h>
 
-namespace fty::messagebus::amqp
+namespace fty::messagebus::amqp {
+using namespace fty::messagebus;
+using proton::receiver_options;
+using proton::source_options;
+
+MsgBusAmqp::~MsgBusAmqp()
 {
-  using namespace fty::messagebus;
-  using proton::receiver_options;
-  using proton::source_options;
-
-  MsgBusAmqp::~MsgBusAmqp()
-  {
     // Cleaning amqp ressources
-    if (isServiceAvailable())
-    {
-      logDebug("Cleaning Amqp ressources for: {}", m_clientName);
+    if (isServiceAvailable()) {
+        logDebug("Cleaning Amqp ressources for: {}", m_clientName);
 
-      for (const auto& [key, receiver] : m_subScriptions)
-      {
-        logDebug("Cleaning: {}...", key);
-        receiver->close();
-      }
-      logDebug("{} cleaned", m_clientName);
+        for (const auto& [key, receiver] : m_subScriptions) {
+            logDebug("Cleaning: {}...", key);
+            receiver->close();
+        }
+        logDebug("{} cleaned", m_clientName);
     }
-  }
+}
 
-  fty::Expected<void> MsgBusAmqp::connect()
-  {
+fty::Expected<void, ComState> MsgBusAmqp::connect()
+{
     logDebug("Connecting for {} to {} ...", m_clientName, m_endpoint);
-    try
-    {
-      m_amqpClient = std::make_shared<AmqpClient>(m_endpoint);
-      std::thread thrdSender([=]() {
-        proton::container(*m_amqpClient).run();
-      });
-      thrdSender.detach();
+    try {
+        m_amqpClient = std::make_shared<AmqpClient>(m_endpoint);
+        std::thread thrdSender([=]() {
+            proton::container(*m_amqpClient).run();
+        });
+        thrdSender.detach();
 
-      if (m_amqpClient->connected() != ComState::COM_STATE_OK)
-      {
-        return fty::unexpected(to_string(m_amqpClient->connected()));
-      }
-    }
-    catch (const std::exception& e)
-    {
-      logError("Unexpected error: {}", e.what());
-      return fty::unexpected(to_string(ComState::COM_STATE_CONNECT_FAILED));
+        if (m_amqpClient->connected() != ComState::Ok) {
+            return fty::unexpected(m_amqpClient->connected());
+        }
+    } catch (const std::exception& e) {
+        logError("Unexpected error: {}", e.what());
+        return fty::unexpected(ComState::ConnectFailed);
     }
     return {};
-  }
+}
 
-  bool MsgBusAmqp::isServiceAvailable()
-  {
-    return (m_amqpClient && (m_amqpClient->connected() == ComState::COM_STATE_OK));
-  }
+bool MsgBusAmqp::isServiceAvailable()
+{
+    return (m_amqpClient && (m_amqpClient->connected() == ComState::Ok));
+}
 
-  fty::Expected<void> MsgBusAmqp::receive(const Address& address, MessageListener messageListener, const std::string& filter)
-  {
-    if (!isServiceAvailable())
-    {
-      logDebug("Service not available");
-      return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_UNAVAILABLE));
+fty::Expected<void, DeliveryState> MsgBusAmqp::receive(const Address& address, MessageListener messageListener, const std::string& filter)
+{
+    if (!isServiceAvailable()) {
+        logDebug("Service not available");
+        return fty::unexpected(DeliveryState::Unavailable);
     }
 
-    auto receiver = std::make_shared<AmqpClient>(m_endpoint);
+    auto        receiver = std::make_shared<AmqpClient>(m_endpoint);
     std::thread thrd([=]() {
-      proton::container(*receiver).run();
+        proton::container(*receiver).run();
     });
-    auto received = receiver->receive(address, filter, messageListener);
+    auto        received = receiver->receive(address, filter, messageListener);
     m_subScriptions.emplace(address, receiver);
     thrd.detach();
 
-    if (received != DeliveryState::DELIVERY_STATE_ACCEPTED)
-    {
-      logError("Message receive (Rejected)");
-      return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_REJECTED));
+    if (received != DeliveryState::Accepted) {
+        logError("Message receive (Rejected)");
+        return fty::unexpected(DeliveryState::Rejected);
     }
     return {};
-  }
+}
 
-  fty::Expected<void> MsgBusAmqp::unreceive(const Address& address)
-  {
-    if (!isServiceAvailable())
-    {
-      logDebug("Service not available");
-      return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_UNAVAILABLE));
+fty::Expected<void, DeliveryState> MsgBusAmqp::unreceive(const Address& address)
+{
+    if (!isServiceAvailable()) {
+        logDebug("Service not available");
+        return fty::unexpected(DeliveryState::Unavailable);
     }
 
-    if (auto it{m_subScriptions.find(address)}; it != m_subScriptions.end())
-    {
-      m_subScriptions.at(address)->unreceive();
-      m_subScriptions.erase(address);
-      logTrace("Unsubscribed for: '{}'", address);
-    }
-    else
-    {
-      logError("Unsubscribed '{}' (Rejected)", address);
-      return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_REJECTED));
+    if (auto it{m_subScriptions.find(address)}; it != m_subScriptions.end()) {
+        m_subScriptions.at(address)->unreceive();
+        m_subScriptions.erase(address);
+        logTrace("Unsubscribed for: '{}'", address);
+    } else {
+        logError("Unsubscribed '{}' (Rejected)", address);
+        return fty::unexpected(DeliveryState::Rejected);
     }
     return {};
-  }
+}
 
-  fty::Expected<void> MsgBusAmqp::send(const Message& message)
-  {
-    if (!isServiceAvailable())
-    {
-      logDebug("Service not available");
-      return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_UNAVAILABLE));
+fty::Expected<void, DeliveryState> MsgBusAmqp::send(const Message& message)
+{
+    if (!isServiceAvailable()) {
+        logDebug("Service not available");
+        return fty::unexpected(DeliveryState::Unavailable);
     }
 
     logDebug("Sending message {}", message.toString());
     proton::message msgToSend = getAmqpMessage(message);
 
-    auto sender = AmqpClient(m_endpoint);
+    auto        sender = AmqpClient(m_endpoint);
     std::thread thrd([&]() {
-      proton::container(sender).run();
+        proton::container(sender).run();
     });
-    auto msgSent = sender.send(msgToSend);
+    auto        msgSent = sender.send(msgToSend);
     sender.close();
     thrd.join();
 
-    if (msgSent != DeliveryState::DELIVERY_STATE_ACCEPTED)
-    {
-      logError("Message sent (Rejected)");
-      return fty::unexpected(to_string(msgSent));
+    if (msgSent != DeliveryState::Accepted) {
+        logError("Message sent (Rejected)");
+        return fty::unexpected(msgSent);
     }
 
     logDebug("Message sent (Accepted)");
     return {};
-  }
+}
 
-  fty::Expected<Message> MsgBusAmqp::request(const Message& message, int receiveTimeOut)
-  {
-    try
-    {
-      if (!isServiceAvailable())
-      {
-        logDebug("Service not available");
-        return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_UNAVAILABLE));
-      }
+fty::Expected<Message, DeliveryState> MsgBusAmqp::request(const Message& message, int receiveTimeOut)
+{
+    try {
+        if (!isServiceAvailable()) {
+            logDebug("Service not available");
+            return fty::unexpected(DeliveryState::Unavailable);
+        }
 
-      proton::message msgToSend = getAmqpMessage(message);
+        proton::message msgToSend = getAmqpMessage(message);
 
-      AmqpClient requester(m_endpoint);
-      std::thread thrd([&]() {
-        proton::container(requester).run();
-      });
-      requester.receive(msgToSend.reply_to(), proton::to_string(msgToSend.correlation_id()));
-      auto msgSent = send(message);
-      if (!msgSent)
-      {
-        return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_REJECTED));
-      }
+        AmqpClient  requester(m_endpoint);
+        std::thread thrd([&]() {
+            proton::container(requester).run();
+        });
+        requester.receive(msgToSend.reply_to(), proton::to_string(msgToSend.correlation_id()));
+        auto msgSent = send(message);
+        if (!msgSent) {
+            return fty::unexpected(DeliveryState::Rejected);
+        }
 
-      MessagePointer response = std::make_shared<proton::message>();
-      bool messageArrived = requester.tryConsumeMessageFor(response, receiveTimeOut);
+        MessagePointer response       = std::make_shared<proton::message>();
+        bool           messageArrived = requester.tryConsumeMessageFor(response, receiveTimeOut);
 
-      requester.close();
-      thrd.join();
+        requester.close();
+        thrd.join();
 
-      if (!messageArrived)
-      {
-        logError("No message arrive in time!");
-        return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_TIMEOUT));
-      }
+        if (!messageArrived) {
+            logError("No message arrive in time!");
+            return fty::unexpected(DeliveryState::Timeout);
+        }
 
-      logDebug("Message arrived ({})", proton::to_string(*response));
-      return Message{getMetaData(*response), response->body().empty() ? std::string{} : proton::to_string(response->body())};
+        logDebug("Message arrived ({})", proton::to_string(*response));
+        return Message{getMetaData(*response), response->body().empty() ? std::string{} : proton::to_string(response->body())};
+    } catch (std::exception& e) {
+        logError("Exception in request: {}", e.what());
+        return fty::unexpected(DeliveryState::Aborted);
     }
-    catch (std::exception& e)
-    {
-      return fty::unexpected(e.what());
-    }
-  }
+}
 
 } // namespace fty::messagebus::amqp

--- a/amqp/src/MsgBusAmqp.h
+++ b/amqp/src/MsgBusAmqp.h
@@ -20,59 +20,56 @@
 #pragma once
 
 #include "AmqpClient.h"
-
 #include <fty/expected.h>
-
 #include <proton/connection_options.hpp>
 #include <proton/container.hpp>
 #include <proton/listen_handler.hpp>
 
-namespace fty::messagebus::amqp
+namespace fty::messagebus::amqp {
+
+using MessagePointer    = std::shared_ptr<proton::message>;
+using AmqpClientPointer = std::shared_ptr<AmqpClient>;
+
+class MsgBusAmqp
 {
-
-  using MessagePointer = std::shared_ptr<proton::message>;
-  using AmqpClientPointer = std::shared_ptr<AmqpClient>;
-
-  class MsgBusAmqp
-  {
-  public:
-
+public:
     MsgBusAmqp(const std::string& clientName, const Endpoint& endpoint)
-      : m_clientName(clientName)
-      , m_endpoint(endpoint){};
+        : m_clientName(clientName)
+        , m_endpoint(endpoint){};
 
     MsgBusAmqp() = delete;
     ~MsgBusAmqp();
 
     MsgBusAmqp(MsgBusAmqp&&) = delete;
     MsgBusAmqp& operator=(MsgBusAmqp&&) = delete;
-    MsgBusAmqp(const MsgBusAmqp&) = delete;
+    MsgBusAmqp(const MsgBusAmqp&)       = delete;
     MsgBusAmqp& operator=(const MsgBusAmqp&) = delete;
 
-    [[nodiscard]] fty::Expected<void> connect();
+    [[nodiscard]] fty::Expected<void, ComState> connect();
 
-    [[nodiscard]] fty::Expected<void> receive(const Address& address, MessageListener messageListener, const std::string& filter = {});
-    [[nodiscard]] fty::Expected<void> unreceive(const Address& address);
-    [[nodiscard]] fty::Expected<void> send(const Message& message);
+    [[nodiscard]] fty::Expected<void, DeliveryState> receive(
+        const Address& address, MessageListener messageListener, const std::string& filter = {});
+    [[nodiscard]] fty::Expected<void, DeliveryState> unreceive(const Address& address);
+    [[nodiscard]] fty::Expected<void, DeliveryState> send(const Message& message);
 
     // Sync request with timeout
-    [[nodiscard]] fty::Expected<Message> request(const Message& message, int receiveTimeOut);
+    [[nodiscard]] fty::Expected<Message, DeliveryState> request(const Message& message, int receiveTimeOut);
 
     const std::string& clientName() const
     {
-      return m_clientName;
+        return m_clientName;
     }
 
     bool isServiceAvailable();
 
-  private:
+private:
     std::string m_clientName{};
-    Endpoint m_endpoint{};
+    Endpoint    m_endpoint{};
 
     // To handle all receivers and theirs message listener
     std::map<std::string, AmqpClientPointer> m_subScriptions;
     // To handle connection, etc.
     AmqpClientPointer m_amqpClient;
-  };
+};
 
 } // namespace fty::messagebus::amqp

--- a/amqp/tests/MessageBusAmqpTest.cpp
+++ b/amqp/tests/MessageBusAmqpTest.cpp
@@ -17,310 +17,308 @@
     =========================================================================
 */
 
+#include <catch2/catch.hpp>
 #include <fty/messagebus/Message.h>
 #include <fty/messagebus/MessageBusStatus.h>
 #include <fty/messagebus/amqp/MessageBusAmqp.h>
 #include <fty/messagebus/utils.h>
-
-#include <catch2/catch.hpp>
 #include <iostream>
-
 #include <mutex>
 #include <thread>
 
-namespace
-{
+namespace {
 
 #if defined(EXTERNAL_SERVER_FOR_TEST)
-  static constexpr auto AMQP_SERVER_URI{"x.x.x.x:5672"};
+static constexpr auto AMQP_SERVER_URI{"x.x.x.x:5672"};
 #else
-  static constexpr auto AMQP_SERVER_URI{"amqp://127.0.0.1:5672"};
+static constexpr auto AMQP_SERVER_URI{"amqp://127.0.0.1:5672"};
 #endif
 
-  using namespace fty::messagebus;
-  using namespace fty::messagebus::utils;
+using namespace fty::messagebus;
+using namespace fty::messagebus::utils;
 
-  auto constexpr ONE_SECOND = std::chrono::seconds(1);
-  auto constexpr TWO_SECONDS = std::chrono::seconds(2);
+auto constexpr ONE_SECOND  = std::chrono::seconds(1);
+auto constexpr TWO_SECONDS = std::chrono::seconds(2);
 
-  static const std::string QUERY = "query";
-  static const std::string QUERY_2 = "query2";
-  static const std::string OK = ":OK";
-  static const std::string QUERY_AND_OK = QUERY + OK;
-  static const std::string RESPONSE_2 = QUERY_2 + OK;
+static const std::string QUERY        = "query";
+static const std::string QUERY_2      = "query2";
+static const std::string OK           = ":OK";
+static const std::string QUERY_AND_OK = QUERY + OK;
+static const std::string RESPONSE_2   = QUERY_2 + OK;
 
-  class MsgReceived
-  {
-  private:
+class MsgReceived
+{
+private:
     // Mutex
     std::mutex m_lock;
 
-  public:
+public:
     int receiver;
     int replyer;
 
     MsgReceived()
-      : receiver(0)
-      , replyer(0)
+        : receiver(0)
+        , replyer(0)
     {
     }
 
     void reset()
     {
-      std::lock_guard<std::mutex> lock(m_lock);
-      receiver = 0;
-      replyer = 0;
+        std::lock_guard<std::mutex> lock(m_lock);
+        receiver = 0;
+        replyer  = 0;
     }
 
     void incReceiver()
     {
-      std::lock_guard<std::mutex> lock(m_lock);
-      receiver++;
+        std::lock_guard<std::mutex> lock(m_lock);
+        receiver++;
     }
 
     void incReplyer()
     {
-      std::lock_guard<std::mutex> lock(m_lock);
-      replyer++;
+        std::lock_guard<std::mutex> lock(m_lock);
+        replyer++;
     }
 
     bool assertValue(const int expected)
     {
-      return (receiver == expected && replyer == expected);
+        return (receiver == expected && replyer == expected);
     }
 
     bool isRecieved(const int expected)
     {
-      return (receiver == expected);
+        return (receiver == expected);
     }
 
     void messageListener(const Message& message)
     {
-      incReceiver();
-      std::cout << "Message arrived " << message.toString() << std::endl;
+        incReceiver();
+        std::cout << "Message arrived " << message.toString() << std::endl;
     }
 
     void replyerAddOK(const Message& message)
     {
-      incReplyer();
-      //Build the response
-      auto response = message.buildReply(message.userData() + OK);
+        incReplyer();
+        // Build the response
+        auto response = message.buildReply(message.userData() + OK);
 
-      if (!response)
-      {
-        std::cerr << response.error() << std::endl;
-      }
+        if (!response) {
+            std::cerr << response.error() << std::endl;
+        }
 
-      //send the response
-      auto msgBus = amqp::MessageBusAmqp("TestCase", AMQP_SERVER_URI);
-      auto connected = msgBus.connect();
-      auto msgSent = msgBus.send(response.value());
-      if (!msgSent)
-      {
-        std::cerr << msgSent.error() << std::endl;
-      }
+        // send the response
+        auto msgBus = amqp::MessageBusAmqp("TestCase", AMQP_SERVER_URI);
+        REQUIRE(msgBus.connect());
+        auto msgSent = msgBus.send(response.value());
+        if (!msgSent) {
+            FAIL(to_string(msgSent.error()));
+        }
     }
-  };
+};
 
-  //----------------------------------------------------------------------
-  // Test case
-  //----------------------------------------------------------------------
+//----------------------------------------------------------------------
+// Test case
+//----------------------------------------------------------------------
 
-  TEST_CASE("Identity", "[amqp][identity]")
-  {
+TEST_CASE("Identity", "[amqp][identity]")
+{
     auto msgBus = amqp::MessageBusAmqp("IdentityTestCase", AMQP_SERVER_URI);
     REQUIRE(msgBus.clientName() == "IdentityTestCase");
     REQUIRE(msgBus.identity() == amqp::BUS_IDENTITY);
-  }
+}
 
-  TEST_CASE("queue", "[amqp][request]")
-  {
+TEST_CASE("queue", "[amqp][request]")
+{
     SECTION("Send request sync timeout reached")
     {
-      std::string syncTimeOutTestQueue = "queue://test.message.synctimeout.";
-      auto msgBus = amqp::MessageBusAmqp("SyncRequesterTimeOutTestCase", AMQP_SERVER_URI);
+        std::string syncTimeOutTestQueue = "queue://test.message.synctimeout.";
+        auto        msgBus               = amqp::MessageBusAmqp("SyncRequesterTimeOutTestCase", AMQP_SERVER_URI);
 
-      REQUIRE(msgBus.connect());
+        REQUIRE(msgBus.connect());
 
-      // Send synchronous request
-      Message request = Message::buildRequest("SyncRequesterTimeOutTestCase", syncTimeOutTestQueue + "request", "TEST", syncTimeOutTestQueue + "reply", "test:");
+        // Send synchronous request
+        Message request = Message::
+            buildRequest("SyncRequesterTimeOutTestCase", syncTimeOutTestQueue + "request", "TEST", syncTimeOutTestQueue + "reply", "test:");
 
-      auto replyMsg = msgBus.request(request, 2);
-      REQUIRE(!replyMsg);
-      REQUIRE(from_deliveryState(replyMsg.error()) == DeliveryState::DELIVERY_STATE_TIMEOUT);
+        auto replyMsg = msgBus.request(request, 2);
+        REQUIRE(!replyMsg);
+        REQUIRE(replyMsg.error() == DeliveryState::Timeout);
     }
 
     SECTION("Send sync request")
     {
-      MsgReceived msgReceived;
-      std::string syncTestQueue = "queue://test.message.sync.";
-      auto msgBusReciever = amqp::MessageBusAmqp("SyncReceiverTestCase", AMQP_SERVER_URI);
+        MsgReceived msgReceived;
+        std::string syncTestQueue  = "queue://test.message.sync.";
+        auto        msgBusReciever = amqp::MessageBusAmqp("SyncReceiverTestCase", AMQP_SERVER_URI);
 
-      // Send synchronous request
-      Message request = Message::buildRequest("SyncRequesterTestCase", syncTestQueue + "request", "SyncTest", syncTestQueue + "reply", QUERY);
+        // Send synchronous request
+        Message request =
+            Message::buildRequest("SyncRequesterTestCase", syncTestQueue + "request", "SyncTest", syncTestQueue + "reply", QUERY);
 
-      REQUIRE(msgBusReciever.connect());
-      REQUIRE(msgBusReciever.receive(request.to(), std::bind(&MsgReceived::replyerAddOK, std::ref(msgReceived), std::placeholders::_1)));
+        REQUIRE(msgBusReciever.connect());
+        REQUIRE(msgBusReciever.receive(request.to(), std::bind(&MsgReceived::replyerAddOK, std::ref(msgReceived), std::placeholders::_1)));
 
-      // Test without connection before.
-      auto msgBusRequester = amqp::MessageBusAmqp("SyncRequesterTestCase", AMQP_SERVER_URI);
-      auto requester = msgBusRequester.request(request, 2);
-      REQUIRE(requester.error() == to_string(DeliveryState::DELIVERY_STATE_UNAVAILABLE));
+        // Test without connection before.
+        auto msgBusRequester = amqp::MessageBusAmqp("SyncRequesterTestCase", AMQP_SERVER_URI);
+        auto requester       = msgBusRequester.request(request, 2);
+        REQUIRE(requester.error() == DeliveryState::Unavailable);
 
-      // Test with connection after.
-      REQUIRE(msgBusRequester.connect());
-      auto replyMsg = msgBusRequester.request(request, 2);
-      REQUIRE(replyMsg.value().userData() == QUERY_AND_OK);
+        // Test with connection after.
+        REQUIRE(msgBusRequester.connect());
+        auto replyMsg = msgBusRequester.request(request, 2);
+        REQUIRE(replyMsg.value().userData() == QUERY_AND_OK);
     }
 
     SECTION("Send async request")
     {
-      MsgReceived msgReceived;
-      std::string asyncTestQueue = "queue://test.message.async.";
-      auto msgBusRequester = amqp::MessageBusAmqp("AsyncRequesterTestCase", AMQP_SERVER_URI);
-      REQUIRE(msgBusRequester.connect());
+        MsgReceived msgReceived;
+        std::string asyncTestQueue  = "queue://test.message.async.";
+        auto        msgBusRequester = amqp::MessageBusAmqp("AsyncRequesterTestCase", AMQP_SERVER_URI);
+        REQUIRE(msgBusRequester.connect());
 
-      auto msgBusReplyer = amqp::MessageBusAmqp("AsyncReplyerTestCase", AMQP_SERVER_URI);
-      REQUIRE(msgBusReplyer.connect());
+        auto msgBusReplyer = amqp::MessageBusAmqp("AsyncReplyerTestCase", AMQP_SERVER_URI);
+        REQUIRE(msgBusReplyer.connect());
 
-      // Build asynchronous request and set all receiver
-      Message request = Message::buildRequest("AsyncRequestTestCase", asyncTestQueue + "request", "TEST", asyncTestQueue + "reply", QUERY);
-      REQUIRE(msgBusReplyer.receive(request.to(), std::bind(&MsgReceived::replyerAddOK, std::ref(msgReceived), std::placeholders::_1)));
-      REQUIRE(msgBusRequester.receive(request.replyTo(), std::bind(&MsgReceived::messageListener, std::ref(msgReceived), std::placeholders::_1), request.correlationId()));
+        // Build asynchronous request and set all receiver
+        Message request =
+            Message::buildRequest("AsyncRequestTestCase", asyncTestQueue + "request", "TEST", asyncTestQueue + "reply", QUERY);
+        REQUIRE(msgBusReplyer.receive(request.to(), std::bind(&MsgReceived::replyerAddOK, std::ref(msgReceived), std::placeholders::_1)));
+        REQUIRE(msgBusRequester.receive(
+            request.replyTo(), std::bind(&MsgReceived::messageListener, std::ref(msgReceived), std::placeholders::_1),
+            request.correlationId()));
 
-      for (int i = 0; i < 3; i++)
-      {
-        REQUIRE(msgBusReplyer.send(request));
-        std::this_thread::sleep_for(TWO_SECONDS);
-        CHECK(msgReceived.assertValue(i + 1));
-      }
+        for (int i = 0; i < 3; i++) {
+            REQUIRE(msgBusReplyer.send(request));
+            std::this_thread::sleep_for(TWO_SECONDS);
+            CHECK(msgReceived.assertValue(i + 1));
+        }
     }
 
     SECTION("Send")
     {
-      MsgReceived msgReceived;
-      std::string sendTestQueue = "queue://test.message.send";
+        MsgReceived msgReceived;
+        std::string sendTestQueue = "queue://test.message.send";
 
-      auto msgBus = amqp::MessageBusAmqp("MessageRecieverSendTestCase", AMQP_SERVER_URI);
-      REQUIRE(msgBus.connect());
+        auto msgBus = amqp::MessageBusAmqp("MessageRecieverSendTestCase", AMQP_SERVER_URI);
+        REQUIRE(msgBus.connect());
 
-      auto msgBusSender = amqp::MessageBusAmqp("MessageSenderSendTestCase", AMQP_SERVER_URI);
-      REQUIRE(msgBusSender.connect());
+        auto msgBusSender = amqp::MessageBusAmqp("MessageSenderSendTestCase", AMQP_SERVER_URI);
+        REQUIRE(msgBusSender.connect());
 
-      REQUIRE(msgBusSender.receive(sendTestQueue, std::bind(&MsgReceived::messageListener, std::ref(msgReceived), std::placeholders::_1)));
+        REQUIRE(
+            msgBusSender.receive(sendTestQueue, std::bind(&MsgReceived::messageListener, std::ref(msgReceived), std::placeholders::_1)));
 
-      // Send message on queue
-      Message msg = Message::buildMessage("MqttMessageTestCase", sendTestQueue, "TEST", QUERY);
+        // Send message on queue
+        Message msg = Message::buildMessage("MqttMessageTestCase", sendTestQueue, "TEST", QUERY);
 
-      for (int i = 0; i < 3; i++)
-      {
-        REQUIRE(msgBusSender.send(msg));
-        std::this_thread::sleep_for(ONE_SECOND);
-        CHECK(msgReceived.isRecieved(i+1));
-      }
+        for (int i = 0; i < 3; i++) {
+            REQUIRE(msgBusSender.send(msg));
+            std::this_thread::sleep_for(ONE_SECOND);
+            CHECK(msgReceived.isRecieved(i + 1));
+        }
     }
-  }
+}
 
-  TEST_CASE("topic", "[amqp][pub]")
-  {
+TEST_CASE("topic", "[amqp][pub]")
+{
     SECTION("Publish subscribe")
     {
-      MsgReceived msgReceived;
-      std::string topic = "topic://test.message.pubsub";
-      auto msgBusSender = amqp::MessageBusAmqp("PubTestCase", AMQP_SERVER_URI);
-      REQUIRE(msgBusSender.connect());
+        MsgReceived msgReceived;
+        std::string topic        = "topic://test.message.pubsub";
+        auto        msgBusSender = amqp::MessageBusAmqp("PubTestCase", AMQP_SERVER_URI);
+        REQUIRE(msgBusSender.connect());
 
-      auto msgBusReceiver = amqp::MessageBusAmqp("PubTestCaseReceiver", AMQP_SERVER_URI);
-      REQUIRE(msgBusReceiver.connect());
+        auto msgBusReceiver = amqp::MessageBusAmqp("PubTestCaseReceiver", AMQP_SERVER_URI);
+        REQUIRE(msgBusReceiver.connect());
 
-      REQUIRE(msgBusReceiver.receive(topic, std::bind(&MsgReceived::messageListener, std::ref(msgReceived), std::placeholders::_1)));
+        REQUIRE(msgBusReceiver.receive(topic, std::bind(&MsgReceived::messageListener, std::ref(msgReceived), std::placeholders::_1)));
 
-      Message msg = Message::buildMessage("PubSubTestCase", topic, "TEST", QUERY);
-      std::this_thread::sleep_for(TWO_SECONDS);
+        Message msg = Message::buildMessage("PubSubTestCase", topic, "TEST", QUERY);
+        std::this_thread::sleep_for(TWO_SECONDS);
 
-      for (int i = 0; i < 3; i++)
-      {
-        auto delivState = msgBusSender.send(msg);
-        REQUIRE(delivState == DeliveryState::DELIVERY_STATE_ACCEPTED);
-        std::this_thread::sleep_for(ONE_SECOND);
-        CHECK(msgReceived.isRecieved(i+1));
-      }
+        for (int i = 0; i < 3; i++) {
+            auto delivState = msgBusSender.send(msg);
+            REQUIRE(delivState);
+            std::this_thread::sleep_for(ONE_SECOND);
+            CHECK(msgReceived.isRecieved(i + 1));
+        }
     }
 
     SECTION("Unreceive")
     {
-      MsgReceived msgReceived;
-      auto msgBus = amqp::MessageBusAmqp("UnreceiveReceiverTestCase", AMQP_SERVER_URI);
-      std::string topic = "topic://test.message.unreceive." + generateUuid();
+        MsgReceived msgReceived;
+        auto        msgBus = amqp::MessageBusAmqp("UnreceiveReceiverTestCase", AMQP_SERVER_URI);
+        std::string topic  = "topic://test.message.unreceive." + generateUuid();
 
-      // Try to unreceive before a connection => UNAVAILABLE
-      REQUIRE(msgBus.unreceive(topic).error() == to_string(DeliveryState::DELIVERY_STATE_UNAVAILABLE));
-      // After a connection
-      REQUIRE(msgBus.connect());
-      REQUIRE(msgBus.receive(topic, std::bind(&MsgReceived::messageListener, std::ref(msgReceived), std::placeholders::_1)));
+        // Try to unreceive before a connection => UNAVAILABLE
+        REQUIRE(msgBus.unreceive(topic).error() == DeliveryState::Unavailable);
+        // After a connection
+        REQUIRE(msgBus.connect());
+        REQUIRE(msgBus.receive(topic, std::bind(&MsgReceived::messageListener, std::ref(msgReceived), std::placeholders::_1)));
 
-      auto msgBusSender = amqp::MessageBusAmqp("UnreceiveSenderTestCase", AMQP_SERVER_URI);
-      REQUIRE(msgBusSender.connect());
+        auto msgBusSender = amqp::MessageBusAmqp("UnreceiveSenderTestCase", AMQP_SERVER_URI);
+        REQUIRE(msgBusSender.connect());
 
-      Message msg = Message::buildMessage("UnreceiveTestCase", topic, "TEST", QUERY);
-      REQUIRE(msgBusSender.send(msg) == DeliveryState::DELIVERY_STATE_ACCEPTED);
-      std::this_thread::sleep_for(TWO_SECONDS);
-      CHECK(msgReceived.isRecieved(1));
+        Message msg = Message::buildMessage("UnreceiveTestCase", topic, "TEST", QUERY);
+        REQUIRE(msgBusSender.send(msg));
+        std::this_thread::sleep_for(TWO_SECONDS);
+        CHECK(msgReceived.isRecieved(1));
 
-      // Try to unreceive a wrong topic => REJECTED
-      REQUIRE(msgBus.unreceive("/etn/t/wrongTopic").error() == to_string(DeliveryState::DELIVERY_STATE_REJECTED));
-      // Try to unreceive a right topic => ACCEPTED
-      REQUIRE(msgBus.unreceive(topic));
-      REQUIRE(msgBusSender.send(msg) == DeliveryState::DELIVERY_STATE_ACCEPTED);
-      std::this_thread::sleep_for(ONE_SECOND);
-      CHECK(msgReceived.isRecieved(1));
+        // Try to unreceive a wrong topic => REJECTED
+        REQUIRE(msgBus.unreceive("/etn/t/wrongTopic").error() == DeliveryState::Rejected);
+        // Try to unreceive a right topic => ACCEPTED
+        REQUIRE(msgBus.unreceive(topic));
+        REQUIRE(msgBusSender.send(msg));
+        std::this_thread::sleep_for(ONE_SECOND);
+        CHECK(msgReceived.isRecieved(1));
     }
 
     SECTION("Pub sub with same object")
     {
-      MsgReceived msgReceived;
-      std::string topic = "topic://test.message.sameobject";
+        MsgReceived msgReceived;
+        std::string topic = "topic://test.message.sameobject";
 
-      auto msgBus = amqp::MessageBusAmqp("PubTestCaseWithSameObject", AMQP_SERVER_URI);
-      REQUIRE(msgBus.connect());
+        auto msgBus = amqp::MessageBusAmqp("PubTestCaseWithSameObject", AMQP_SERVER_URI);
+        REQUIRE(msgBus.connect());
 
-      REQUIRE(msgBus.receive(topic, std::bind(&MsgReceived::messageListener, std::ref(msgReceived), std::placeholders::_1)));
+        REQUIRE(msgBus.receive(topic, std::bind(&MsgReceived::messageListener, std::ref(msgReceived), std::placeholders::_1)));
 
-      Message msg = Message::buildMessage("PubTestCaseWithSameObject", topic, "TEST", QUERY);
-      std::this_thread::sleep_for(TWO_SECONDS);
+        Message msg = Message::buildMessage("PubTestCaseWithSameObject", topic, "TEST", QUERY);
+        std::this_thread::sleep_for(TWO_SECONDS);
 
-      REQUIRE(msgBus.send(msg) == DeliveryState::DELIVERY_STATE_ACCEPTED);
-      std::this_thread::sleep_for(ONE_SECOND);
-      CHECK(msgReceived.isRecieved(1));
+        REQUIRE(msgBus.send(msg));
+        std::this_thread::sleep_for(ONE_SECOND);
+        CHECK(msgReceived.isRecieved(1));
     }
-  }
+}
 
-  TEST_CASE("wrong", "[amqp][messageStatus]")
-  {
+TEST_CASE("wrong", "[amqp][messageStatus]")
+{
     SECTION("Wrong message")
     {
-      auto msgBus = amqp::MessageBusAmqp("WrongMessageTestCase", AMQP_SERVER_URI);
+        auto msgBus = amqp::MessageBusAmqp("WrongMessageTestCase", AMQP_SERVER_URI);
 
-      // Without mandatory fields (from, subject, to)
-      auto wrongSendMsg = Message::buildMessage("WrongMessageTestCase", "", "TEST");
-      REQUIRE(msgBus.send(wrongSendMsg).error() == to_string(DeliveryState::DELIVERY_STATE_REJECTED));
+        // Without mandatory fields (from, subject, to)
+        auto wrongSendMsg = Message::buildMessage("WrongMessageTestCase", "", "TEST");
+        REQUIRE(msgBus.send(wrongSendMsg).error() == DeliveryState::Rejected);
 
-      // Without mandatory fields (from, subject, to)
-      auto request = Message::buildRequest("WrongRequestTestCase", "", "SyncTest", "", QUERY);
-      // Request reject
-      REQUIRE(msgBus.request(request, 1).error() == to_string(DeliveryState::DELIVERY_STATE_REJECTED));
-      request.from("queue://etn.q.request");
-      request.to("queue://etn.q.reply");
-      // Without reply request reject.
-      REQUIRE(msgBus.request(request, 1).error() == to_string(DeliveryState::DELIVERY_STATE_REJECTED));
+        // Without mandatory fields (from, subject, to)
+        auto request = Message::buildRequest("WrongRequestTestCase", "", "SyncTest", "", QUERY);
+        // Request reject
+        REQUIRE(msgBus.request(request, 1).error() == DeliveryState::Rejected);
+        request.from("queue://etn.q.request");
+        request.to("queue://etn.q.reply");
+        // Without reply request reject.
+        REQUIRE(msgBus.request(request, 1).error() == DeliveryState::Rejected);
     }
 
     SECTION("Wrong ip address")
     {
-      auto msgBus = amqp::MessageBusAmqp("WrongConnectionTestCase", "amqp://wrong.address.ip.com:5672");
-      auto connectionRet = msgBus.connect();
-      REQUIRE(connectionRet.error() == to_string(ComState::COM_STATE_CONNECT_FAILED));
+        auto msgBus        = amqp::MessageBusAmqp("WrongConnectionTestCase", "amqp://wrong.address.ip.com:5672");
+        auto connectionRet = msgBus.connect();
+        REQUIRE(connectionRet.error() == ComState::ConnectFailed);
     }
-  }
+}
 
 } // namespace

--- a/amqp/tests/MsgBusAmqpTest.cpp
+++ b/amqp/tests/MsgBusAmqpTest.cpp
@@ -18,45 +18,42 @@
 */
 
 #include "src/MsgBusAmqp.h"
+#include <catch2/catch.hpp>
 #include <fty/messagebus/Message.h>
 #include <fty/messagebus/MessageBusStatus.h>
-
-#include <catch2/catch.hpp>
 #include <iostream>
-
 #include <thread>
 
-namespace
-{
+namespace {
+
 #if defined(EXTERNAL_SERVER_FOR_TEST)
-  static constexpr auto AMQP_SERVER_URI{"x.x.x.x:5672"};
+static constexpr auto AMQP_SERVER_URI{"x.x.x.x:5672"};
 #else
-  static constexpr auto AMQP_SERVER_URI{"amqp://127.0.0.1:5672"};
+static constexpr auto AMQP_SERVER_URI{"amqp://127.0.0.1:5672"};
 #endif
 
-  using namespace fty::messagebus;
+using namespace fty::messagebus;
 
 } // namespace
 
 TEST_CASE("Amqp with no connection", "[MsgBusAmqp]")
 {
-  std::string topic = "topic://test.no.connection";
-  Message msg = Message::buildMessage("AmqpNoConnectionTestCase", topic, "TEST", "QUERY");
+    std::string topic = "topic://test.no.connection";
+    Message     msg   = Message::buildMessage("AmqpNoConnectionTestCase", topic, "TEST", "QUERY");
 
-  auto msgBus = amqp::MsgBusAmqp("AmqpNoConnectionTestCase", AMQP_SERVER_URI);
-  auto received = msgBus.receive(topic, {});
-  REQUIRE(received.error() == to_string(DeliveryState::DELIVERY_STATE_UNAVAILABLE));
-  auto sent = msgBus.send(msg);
-  REQUIRE(sent.error() == to_string(DeliveryState::DELIVERY_STATE_UNAVAILABLE));
+    auto msgBus   = amqp::MsgBusAmqp("AmqpNoConnectionTestCase", AMQP_SERVER_URI);
+    auto received = msgBus.receive(topic, {});
+    REQUIRE(received.error() == DeliveryState::Unavailable);
+    auto sent = msgBus.send(msg);
+    REQUIRE(sent.error() == DeliveryState::Unavailable);
 }
 
 TEST_CASE("Amqp without and with connection", "[MsgBusAmqp]")
 {
-  auto msgBus = amqp::MsgBusAmqp("AmqpMessageBusStatusTestCase", AMQP_SERVER_URI);
-  CHECK_FALSE(msgBus.isServiceAvailable());
-  auto connectionRet = msgBus.connect();
-  REQUIRE(msgBus.connect());
-  REQUIRE(msgBus.isServiceAvailable());
+    auto msgBus = amqp::MsgBusAmqp("AmqpMessageBusStatusTestCase", AMQP_SERVER_URI);
+    CHECK_FALSE(msgBus.isServiceAvailable());
+    REQUIRE(msgBus.connect());
+    REQUIRE(msgBus.isServiceAvailable());
 
-  REQUIRE(msgBus.clientName() == "AmqpMessageBusStatusTestCase");
+    REQUIRE(msgBus.clientName() == "AmqpMessageBusStatusTestCase");
 }

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -7,25 +7,23 @@ project(fty-common-messagebus2
 find_package(fty-cmake PATHS ${CMAKE_BINARY_DIR}/fty-cmake REQUIRED)
 ##############################################################################################################
 
-etn_target(shared fty-common-messagebus2
-  SOURCES
-    src/*.cpp
-  PUBLIC_INCLUDE_DIR
-    public_include
-  PUBLIC_HEADERS
-    *.h
-  USES_PRIVATE
-    uuid
+etn_target(shared ${PROJECT_NAME}
+    SOURCES
+        src/*.cpp
+    PUBLIC_INCLUDE_DIR
+        public_include
+    PUBLIC_HEADERS
+        *.h
+    USES_PUBLIC
+        fty-utils
+    USES_PRIVATE
+        uuid
 )
 
 set_target_properties(fty-common-messagebus2 PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR})
 
 ## Tests
-if(BUILD_TESTING)
-  etn_test_target(${PROJECT_NAME}
+etn_test_target(${PROJECT_NAME}
     SOURCES
-      tests/*.cpp
-    USES
-      fty-utils
-  )
-endif()
+        tests/*.cpp
+)

--- a/common/public_include/fty/messagebus/Message.h
+++ b/common/public_include/fty/messagebus/Message.h
@@ -23,77 +23,83 @@
 #include <map>
 #include <string>
 
-namespace fty::messagebus
+namespace fty::messagebus {
+
+using UserData = std::string;
+using MetaData = std::map<std::string, std::string>;
+using Address  = std::string;
+
+static constexpr auto STATUS_OK = "OK";
+static constexpr auto STATUS_KO = "KO";
+
+// Metadata user property
+static constexpr auto CORRELATION_ID = "CORRELATION_ID"; // Correlation Id used for request reply pattern
+static constexpr auto MESSAGE_ID     = "MESSAGE_ID";     // Message Id
+static constexpr auto FROM           = "FROM";           // ClientId of the message
+static constexpr auto TO             = "TO";             // Destination queue
+static constexpr auto REPLY_TO       = "REPLY_TO";       // Reply queue
+static constexpr auto SUBJECT        = "SUBJECT";        // Message subject
+static constexpr auto STATUS         = "STATUS";         // Message status
+
+class Message
 {
-  using UserData = std::string;
-  using MetaData = std::map<std::string, std::string>;
-  using Address = std::string;
-
-  static constexpr auto STATUS_OK = "OK";
-  static constexpr auto STATUS_KO = "KO";
-
-  // Metadata user property
-  static constexpr auto CORRELATION_ID = "CORRELATION_ID"; // Correlation Id used for request reply pattern
-  static constexpr auto MESSAGE_ID     = "MESSAGE_ID";     // Message Id
-  static constexpr auto FROM           = "FROM";           // ClientId of the message
-  static constexpr auto TO             = "TO";             // Destination queue
-  static constexpr auto REPLY_TO       = "REPLY_TO";       // Reply queue
-  static constexpr auto SUBJECT        = "SUBJECT";        // Message subject
-  static constexpr auto STATUS         = "STATUS";         // Message status
-
-  class Message;
-  class Message
-  {
-  public:
+public:
     Message() = default;
     Message(const MetaData& metaData, const UserData& userData);
     Message(const Message& message);
     Message(const UserData& userData);
 
     ~Message() noexcept = default;
-    Message& operator=(const Message& other);
+    Message& operator   =(const Message& other);
 
-    MetaData& metaData();
+    MetaData&       metaData();
     const MetaData& metaData() const;
-    void metaData(const MetaData& metaData);
+    void            metaData(const MetaData& metaData);
 
-    UserData& userData();
+    UserData&       userData();
     const UserData& userData() const;
-    void userData(const UserData& userData);
+    void            userData(const UserData& userData);
 
     std::string correlationId() const;
-    void correlationId(const std::string& correlationId);
+    void        correlationId(const std::string& correlationId);
     std::string from() const;
-    void from(const std::string& from);
+    void        from(const std::string& from);
     std::string to() const;
-    void to(const std::string& to);
+    void        to(const std::string& to);
     std::string replyTo() const;
-    void replyTo(const std::string& replyTo);
+    void        replyTo(const std::string& replyTo);
     std::string subject() const;
-    void subject(const std::string& subject);
+    void        subject(const std::string& subject);
     std::string status() const;
-    void status(const std::string& status);
+    void        status(const std::string& status);
     std::string id() const;
-    void id(const std::string& id);
+    void        id(const std::string& id);
 
     std::string getMetaDataValue(const std::string& key) const;
-    void setMetaDataValue(const std::string& key, const std::string& data);
+    void        setMetaDataValue(const std::string& key, const std::string& data);
 
     bool isValidMessage() const;
     bool isRequest() const;
     bool needReply() const;
 
     fty::Expected<Message> buildReply(const UserData& userData, const std::string& status = STATUS_OK) const;
-    static Message buildMessage(const Address& from, const Address& to, const std::string& subject, const UserData& userData = {}, const MetaData& meta = {});
-    static Message buildRequest(const Address& from, const Address& to, const std::string& subject, const Address& replyTo, const UserData& userData = {}, const MetaData& meta = {});
+    static Message         buildMessage(
+                const Address& from, const Address& to, const std::string& subject, const UserData& userData = {}, const MetaData& meta = {});
+    static Message buildRequest(
+        const Address&     from,
+        const Address&     to,
+        const std::string& subject,
+        const Address&     replyTo,
+        const UserData&    userData = {},
+        const MetaData&    meta     = {});
 
     MetaData getUndefinedProperties() const;
 
     std::string toString() const;
 
-  protected:
+protected:
     MetaData m_metadata;
     UserData m_data;
-  };
+};
 
 } // namespace fty::messagebus

--- a/common/public_include/fty/messagebus/MessageBus.h
+++ b/common/public_include/fty/messagebus/MessageBus.h
@@ -19,53 +19,53 @@
 
 #pragma once
 
+#include "fty/messagebus/Message.h"
+#include "fty/messagebus/MessageBusStatus.h"
+#include <fty/expected.h>
 #include <functional>
 #include <memory>
 #include <optional>
 #include <string>
 
-#include <fty/expected.h>
-#include "fty/messagebus/Message.h"
+namespace fty::messagebus {
+using ClientName = std::string;
+using Endpoint   = std::string;
+using Identity   = std::string;
 
-namespace fty::messagebus
+using MessageListener = std::function<void(const Message&)>;
+
+class MessageBus
 {
-  using ClientName = std::string;
-  using Endpoint = std::string;
-  using Identity = std::string;
-
-  using MessageListener = std::function<void(const Message&)>;
-
-  class MessageBus
-  {
-  public:
+public:
     MessageBus() noexcept = default;
     virtual ~MessageBus() = default;
 
-    MessageBus(const MessageBus&) = delete;
-    MessageBus& operator=(const MessageBus&) = delete;
-    MessageBus(MessageBus&&) noexcept = delete;
+    MessageBus(const MessageBus&) = default;
+    MessageBus& operator=(const MessageBus&) = default;
+    MessageBus(MessageBus&&) noexcept        = delete;
     MessageBus& operator=(MessageBus&&) = delete;
 
     /// Connect to the MessageBus
     /// @return Success or Com Error
-    virtual [[nodiscard]] fty::Expected<void> connect() noexcept = 0;
+    [[nodiscard]] virtual fty::Expected<void, ComState> connect() noexcept = 0;
 
     /// Send a message
     /// @param msg the message object to send
     /// @return Success or Delivery error
-    virtual [[nodiscard]] fty::Expected<void> send(const Message& msg) noexcept = 0;
+    [[nodiscard]] virtual fty::Expected<void, DeliveryState> send(const Message& msg) noexcept = 0;
 
     /// Register a listener to a address using function
     /// @param address the address to receive
     /// @param func the function to receive
     /// @param filter constraint the receiver with a filter
     /// @return Success or error
-    virtual [[nodiscard]] fty::Expected<void> receive(const Address& address, MessageListener&& func, const std::string& filter = {}) noexcept = 0;
+    [[nodiscard]] virtual fty::Expected<void, DeliveryState> receive(
+        const Address& address, MessageListener&& func, const std::string& filter = {}) noexcept = 0;
 
     /// Unsubscribe from a address
     /// @param address the address to unsubscribe
     /// @return Success or error
-    virtual [[nodiscard]] fty::Expected<void> unreceive(const Address& address) noexcept = 0;
+    [[nodiscard]] virtual fty::Expected<void, DeliveryState> unreceive(const Address& address) noexcept = 0;
 
     /// Register a listener to a address using class
     /// @example
@@ -75,7 +75,7 @@ namespace fty::messagebus
     /// @param cls class instance
     /// @return Success or error
     template <typename Func, typename Cls>
-    [[nodiscard]] fty::Expected<void> receive(const Address& address, Func&& fnc, Cls* cls) noexcept
+    [[nodiscard]] fty::Expected<void, DeliveryState> receive(const Address& address, Func&& fnc, Cls* cls) noexcept
     {
         return registerListener(address, [f = std::move(fnc), c = cls](const Message& msg) -> void {
             std::invoke(f, *c, Message(msg));
@@ -86,16 +86,15 @@ namespace fty::messagebus
     /// @param msg the message to send
     /// @param timeOut the timeout in seconds for the request
     /// @return Response message or Delivery error
-    virtual [[nodiscard]] fty::Expected<Message> request(const Message& msg, int timeOut) noexcept = 0;
+    [[nodiscard]] virtual fty::Expected<Message, DeliveryState> request(const Message& msg, int timeOut) noexcept = 0;
 
     /// Get the client name
     /// @return Client name
-    virtual [[nodiscard]] const ClientName & clientName() const noexcept = 0;
+    [[nodiscard]] virtual const ClientName& clientName() const noexcept = 0;
 
     /// Get MessageBus Identity
     /// @return MessageBus Identity
-    virtual [[nodiscard]] const Identity & identity() const noexcept = 0;
-
-  };
+    [[nodiscard]] virtual const Identity& identity() const noexcept = 0;
+};
 
 } // namespace fty::messagebus

--- a/common/public_include/fty/messagebus/MessageBusStatus.h
+++ b/common/public_include/fty/messagebus/MessageBusStatus.h
@@ -21,157 +21,123 @@
 
 #include <string>
 
-namespace fty::messagebus
+namespace fty::messagebus {
+
+enum class ComState
 {
-  enum ComState : uint8_t
-  {
-    COM_STATE_UNKNOWN = 0,
-    COM_STATE_NONE = 1,
-    COM_STATE_OK = 2,
-    COM_STATE_LOST = 3,
-    COM_STATE_NO_CONTACT = 4,
-    COM_STATE_CONNECT_FAILED = 5,
-    COM_STATE_UNDEFINED = 6,
-  };
+    Unknown       = 0,
+    None          = 1,
+    Ok            = 2,
+    Lost          = 3,
+    NoContact     = 4,
+    ConnectFailed = 5,
+    Undefined     = 6,
+};
 
-  inline std::string to_string(const ComState& state)
-  {
-    switch (state)
-    {
-      case COM_STATE_UNKNOWN:
-        return "UNKNOWN";
-      case COM_STATE_NONE:
-        return "NONE";
-      case COM_STATE_OK:
-        return "OK";
-      case COM_STATE_LOST:
-        return "LOST";
-      case COM_STATE_NO_CONTACT:
-        return "NO CONTACT";
-      case COM_STATE_CONNECT_FAILED:
-        return "CONNECTION FAILED";
-      default:
-        break;
+inline std::string to_string(const ComState& state)
+{
+    switch (state) {
+        case ComState::Unknown:
+            return "UNKNOWN";
+        case ComState::None:
+            return "NONE";
+        case ComState::Ok:
+            return "OK";
+        case ComState::Lost:
+            return "LOST";
+        case ComState::NoContact:
+            return "NO CONTACT";
+        case ComState::ConnectFailed:
+            return "CONNECTION FAILED";
+        default:
+            break;
     }
     return "UNDEFINED";
-  }
+}
 
-  inline ComState from_com_state(const std::string& state)
-  {
-    if (state == to_string(ComState::COM_STATE_UNKNOWN))
-    {
-      return ComState::COM_STATE_UNKNOWN;
+inline ComState from_com_state(const std::string& state)
+{
+    if (state == to_string(ComState::Unknown)) {
+        return ComState::Unknown;
+    } else if (state == to_string(ComState::None)) {
+        return ComState::None;
+    } else if (state == to_string(ComState::Ok)) {
+        return ComState::Ok;
+    } else if (state == to_string(ComState::Lost)) {
+        return ComState::Lost;
+    } else if (state == to_string(ComState::NoContact)) {
+        return ComState::NoContact;
+    } else if (state == to_string(ComState::ConnectFailed)) {
+        return ComState::ConnectFailed;
+    } else {
+        return ComState::Undefined;
     }
-    else if (state == to_string(ComState::COM_STATE_NONE))
-    {
-      return ComState::COM_STATE_NONE;
-    }
-    else if (state == to_string(ComState::COM_STATE_OK))
-    {
-      return ComState::COM_STATE_OK;
-    }
-    else if (state == to_string(ComState::COM_STATE_LOST))
-    {
-      return ComState::COM_STATE_LOST;
-    }
-    else if (state == to_string(ComState::COM_STATE_NO_CONTACT))
-    {
-      return ComState::COM_STATE_NO_CONTACT;
-    }
-    else if (state == to_string(ComState::COM_STATE_CONNECT_FAILED))
-    {
-      return ComState::COM_STATE_CONNECT_FAILED;
-    }
-    else
-    {
-      return ComState::COM_STATE_UNDEFINED;
-    }
-  }
+}
 
-  enum DeliveryState : uint8_t
-  {
-    DELIVERY_STATE_UNKNOWN = 0,
-    DELIVERY_STATE_ACCEPTED = 1,
-    DELIVERY_STATE_REJECTED = 2,
-    DELIVERY_STATE_TIMEOUT = 3,
-    DELIVERY_STATE_NOT_SUPPORTED = 4,
-    DELIVERY_STATE_PENDING = 5,
-    DELIVERY_STATE_BUSY = 6,
-    DELIVERY_STATE_ABORTED = 7,
-    DELIVERY_STATE_UNAVAILABLE = 9,
-    DELIVERY_STATE_UNDEFINED = 10
-  };
+enum class DeliveryState
+{
+    Unknown      = 0,
+    Accepted     = 1,
+    Rejected     = 2,
+    Timeout      = 3,
+    NotSupported = 4,
+    Pending      = 5,
+    Busy         = 6,
+    Aborted      = 7,
+    Unavailable  = 9,
+    Udefined     = 10
+};
 
-  inline std::string to_string(const DeliveryState& state)
-  {
-    switch (state)
-    {
-      case DELIVERY_STATE_UNKNOWN:
-        return "UNKNOWN";
-      case DELIVERY_STATE_ACCEPTED:
-        return "ACCEPTED";
-      case DELIVERY_STATE_REJECTED:
-        return "REJECTED";
-      case DELIVERY_STATE_TIMEOUT:
-        return "TIMEOUT";
-      case DELIVERY_STATE_NOT_SUPPORTED:
-        return "NOT SUPPORTED";
-      case DELIVERY_STATE_PENDING:
-        return "PENDING";
-      case DELIVERY_STATE_BUSY:
-        return "BUSY";
-      case DELIVERY_STATE_ABORTED:
-        return "ABORTED";
-      case DELIVERY_STATE_UNAVAILABLE:
-        return "SERVICE UNAVAILABLE";
-      default:
-        break;
+inline std::string to_string(const DeliveryState& state)
+{
+    switch (state) {
+        case DeliveryState::Unknown:
+            return "UNKNOWN";
+        case DeliveryState::Accepted:
+            return "ACCEPTED";
+        case DeliveryState::Rejected:
+            return "REJECTED";
+        case DeliveryState::Timeout:
+            return "TIMEOUT";
+        case DeliveryState::NotSupported:
+            return "NOT SUPPORTED";
+        case DeliveryState::Pending:
+            return "PENDING";
+        case DeliveryState::Busy:
+            return "BUSY";
+        case DeliveryState::Aborted:
+            return "ABORTED";
+        case DeliveryState::Unavailable:
+            return "SERVICE UNAVAILABLE";
+        default:
+            break;
     }
     return "UNDEFINED";
-  }
+}
 
-  inline DeliveryState from_deliveryState(const std::string& deliveryState)
-  {
-    if (deliveryState == to_string(DeliveryState::DELIVERY_STATE_UNKNOWN))
-    {
-      return DeliveryState::DELIVERY_STATE_UNKNOWN;
+inline DeliveryState from_deliveryState(const std::string& deliveryState)
+{
+    if (deliveryState == to_string(DeliveryState::Unknown)) {
+        return DeliveryState::Unknown;
+    } else if (deliveryState == to_string(DeliveryState::Accepted)) {
+        return DeliveryState::Accepted;
+    } else if (deliveryState == to_string(DeliveryState::Rejected)) {
+        return DeliveryState::Rejected;
+    } else if (deliveryState == to_string(DeliveryState::Timeout)) {
+        return DeliveryState::Timeout;
+    } else if (deliveryState == to_string(DeliveryState::NotSupported)) {
+        return DeliveryState::NotSupported;
+    } else if (deliveryState == to_string(DeliveryState::Pending)) {
+        return DeliveryState::Pending;
+    } else if (deliveryState == to_string(DeliveryState::Busy)) {
+        return DeliveryState::Busy;
+    } else if (deliveryState == to_string(DeliveryState::Aborted)) {
+        return DeliveryState::Aborted;
+    } else if (deliveryState == to_string(DeliveryState::Unavailable)) {
+        return DeliveryState::Unavailable;
+    } else {
+        return DeliveryState::Udefined;
     }
-    else if (deliveryState == to_string(DeliveryState::DELIVERY_STATE_ACCEPTED))
-    {
-      return DeliveryState::DELIVERY_STATE_ACCEPTED;
-    }
-    else if (deliveryState == to_string(DeliveryState::DELIVERY_STATE_REJECTED))
-    {
-      return DeliveryState::DELIVERY_STATE_REJECTED;
-    }
-    else if (deliveryState == to_string(DeliveryState::DELIVERY_STATE_TIMEOUT))
-    {
-      return DeliveryState::DELIVERY_STATE_TIMEOUT;
-    }
-    else if (deliveryState == to_string(DeliveryState::DELIVERY_STATE_NOT_SUPPORTED))
-    {
-      return DeliveryState::DELIVERY_STATE_NOT_SUPPORTED;
-    }
-    else if (deliveryState == to_string(DeliveryState::DELIVERY_STATE_PENDING))
-    {
-      return DeliveryState::DELIVERY_STATE_PENDING;
-    }
-    else if (deliveryState == to_string(DeliveryState::DELIVERY_STATE_BUSY))
-    {
-      return DeliveryState::DELIVERY_STATE_BUSY;
-    }
-    else if (deliveryState == to_string(DeliveryState::DELIVERY_STATE_ABORTED))
-    {
-      return DeliveryState::DELIVERY_STATE_ABORTED;
-    }
-    else if (deliveryState == to_string(DeliveryState::DELIVERY_STATE_UNAVAILABLE))
-    {
-      return DeliveryState::DELIVERY_STATE_UNAVAILABLE;
-    }
-    else
-    {
-      return DeliveryState::DELIVERY_STATE_UNDEFINED;
-    }
-  }
+}
 
 } // namespace fty::messagebus

--- a/common/public_include/fty/messagebus/utils.h
+++ b/common/public_include/fty/messagebus/utils.h
@@ -21,18 +21,18 @@
 
 #include <string>
 
-namespace fty::messagebus::utils
-{
-  /// Generate an unique UUID
-  /// @return Uuid built
-  const std::string generateUuid();
+namespace fty::messagebus::utils {
 
-  /// Generate an id
-  /// @return Id built
-  const std::string generateId();
+/// Generate an unique UUID
+/// @return Uuid built
+const std::string generateUuid();
 
-  /// Generate a client id based on clock and prefix
-  /// @return Client id built
-  const std::string getClientId(const std::string& prefix);
+/// Generate an id
+/// @return Id built
+const std::string generateId();
+
+/// Generate a client id based on clock and prefix
+/// @return Client id built
+const std::string getClientId(const std::string& prefix);
 
 } // namespace fty::messagebus::utils

--- a/common/src/Message.cpp
+++ b/common/src/Message.cpp
@@ -17,161 +17,159 @@
     =========================================================================
 */
 #include <fty/messagebus/Message.h>
-
 #include <fty/messagebus/utils.h>
 
-namespace fty::messagebus
-{
+namespace fty::messagebus {
 
-  Message::Message(const MetaData& metaData, const UserData& userData)
+Message::Message(const MetaData& metaData, const UserData& userData)
     : m_metadata(metaData)
     , m_data(userData)
-  {
-  }
+{
+}
 
-  Message::Message(const Message& message)
+Message::Message(const Message& message)
     : Message(message.metaData(), message.userData())
-  {
-  }
+{
+}
 
-  Message::Message(const UserData& userData)
+Message::Message(const UserData& userData)
     : Message({}, userData)
-  {
-  }
+{
+}
 
-  MetaData& Message::metaData()
-  {
+MetaData& Message::metaData()
+{
     return m_metadata;
-  }
+}
 
-  const MetaData& Message::metaData() const
-  {
+const MetaData& Message::metaData() const
+{
     return m_metadata;
-  }
+}
 
-  void Message::metaData(const MetaData& metaData)
-  {
+void Message::metaData(const MetaData& metaData)
+{
     m_metadata = metaData;
-  }
+}
 
-  UserData& Message::userData()
-  {
+UserData& Message::userData()
+{
     return m_data;
-  }
+}
 
-  const UserData& Message::userData() const
-  {
+const UserData& Message::userData() const
+{
     return m_data;
-  }
+}
 
-  void Message::userData(const UserData& userData)
-  {
+void Message::userData(const UserData& userData)
+{
     m_data = userData;
-  }
+}
 
-  std::string Message::getMetaDataValue(const std::string& key) const
-  {
-    std::string value{};
-    if (auto iter{m_metadata.find(key)}; iter != m_metadata.end())
-    {
-      value = iter->second;
+std::string Message::getMetaDataValue(const std::string& key) const
+{
+    std::string value;
+    if (auto iter{m_metadata.find(key)}; iter != m_metadata.end()) {
+        value = iter->second;
     }
     return value;
-  }
+}
 
-  void Message::setMetaDataValue(const std::string& key, const std::string& data)
-  {
+void Message::setMetaDataValue(const std::string& key, const std::string& data)
+{
     m_metadata[key] = data;
-  }
+}
 
-  std::string Message::correlationId() const
-  {
+std::string Message::correlationId() const
+{
     return getMetaDataValue(CORRELATION_ID);
-  }
+}
 
-  void Message::correlationId(const std::string& correlationId)
-  {
+void Message::correlationId(const std::string& correlationId)
+{
     setMetaDataValue(CORRELATION_ID, correlationId);
-  }
+}
 
-  std::string Message::from() const
-  {
+std::string Message::from() const
+{
     return getMetaDataValue(FROM);
-  }
+}
 
-  void Message::from(const std::string& from)
-  {
+void Message::from(const std::string& from)
+{
     setMetaDataValue(FROM, from);
-  }
+}
 
-  std::string Message::to() const
-  {
+std::string Message::to() const
+{
     return getMetaDataValue(TO);
-  }
+}
 
-  void Message::to(const std::string& to)
-  {
+void Message::to(const std::string& to)
+{
     setMetaDataValue(TO, to);
-  }
+}
 
-  std::string Message::replyTo() const
-  {
+std::string Message::replyTo() const
+{
     return getMetaDataValue(REPLY_TO);
-  }
+}
 
-  void Message::replyTo(const std::string& replyTo)
-  {
+void Message::replyTo(const std::string& replyTo)
+{
     setMetaDataValue(REPLY_TO, replyTo);
-  }
+}
 
-  std::string Message::subject() const
-  {
+std::string Message::subject() const
+{
     return getMetaDataValue(SUBJECT);
-  }
+}
 
-  void Message::subject(const std::string& subject)
-  {
+void Message::subject(const std::string& subject)
+{
     setMetaDataValue(SUBJECT, subject);
-  }
+}
 
-  std::string Message::status() const
-  {
+std::string Message::status() const
+{
     return getMetaDataValue(STATUS);
-  }
+}
 
-  void Message::status(const std::string& status)
-  {
+void Message::status(const std::string& status)
+{
     setMetaDataValue(STATUS, status);
-  }
+}
 
-  std::string Message::id() const
-  {
+std::string Message::id() const
+{
     return getMetaDataValue(MESSAGE_ID);
-  }
+}
 
-  void Message::id(const std::string& msgId)
-  {
+void Message::id(const std::string& msgId)
+{
     setMetaDataValue(MESSAGE_ID, msgId);
-  }
+}
 
-  bool Message::isValidMessage() const
-  {
+bool Message::isValidMessage() const
+{
     return ((!subject().empty()) && (!from().empty()) && (!to().empty()));
-  }
+}
 
-  bool Message::isRequest() const
-  {
+bool Message::isRequest() const
+{
     return ((!correlationId().empty()) && isValidMessage());
-  }
+}
 
-  bool Message::needReply() const
-  {
-    //Check that request have all the proper field set
+bool Message::needReply() const
+{
+    // Check that request have all the proper field set
     return (!replyTo().empty() && isRequest());
-  }
+}
 
-  Message Message::buildMessage(const Address& from, const Address& to, const std::string& subject, const UserData& userData, const MetaData& meta)
-  {
+Message Message::buildMessage(
+    const Address& from, const Address& to, const std::string& subject, const UserData& userData, const MetaData& meta)
+{
     Message msg;
     msg.metaData(meta);
 
@@ -181,23 +179,29 @@ namespace fty::messagebus
     msg.userData(userData);
 
     return msg;
-  }
+}
 
-  Message Message::buildRequest(const Address& from, const Address& to, const std::string& subject, const Address& replyTo, const UserData& userData, const MetaData& meta)
-  {
+Message Message::buildRequest(
+    const Address&     from,
+    const Address&     to,
+    const std::string& subject,
+    const Address&     replyTo,
+    const UserData&    userData,
+    const MetaData&    meta)
+{
     Message msg = buildMessage(from, to, subject, userData, meta);
     msg.replyTo(replyTo);
     msg.correlationId(utils::generateUuid());
 
     return msg;
-  }
+}
 
-  fty::Expected<Message> Message::buildReply(const UserData& userData, const std::string& status) const
-  {
+fty::Expected<Message> Message::buildReply(const UserData& userData, const std::string& status) const
+{
     if (!isValidMessage())
-      return fty::unexpected("Not a valid message!");
+        return fty::unexpected("Not a valid message!");
     if (!needReply())
-      return fty::unexpected("No where to reply!");
+        return fty::unexpected("No where to reply!");
 
     Message reply;
     reply.from(to());
@@ -208,42 +212,39 @@ namespace fty::messagebus
     reply.userData(userData);
 
     return reply;
-  }
+}
 
-  MetaData Message::getUndefinedProperties() const
-  {
+MetaData Message::getUndefinedProperties() const
+{
     MetaData metaData;
-    for (const auto& [key, value] : m_metadata)
-    {
-      if (key != CORRELATION_ID && key != FROM && key != TO && key != REPLY_TO && key != SUBJECT)
-      {
-        metaData.emplace(key, value);
-      }
+    for (const auto& [key, value] : m_metadata) {
+        if (key != CORRELATION_ID && key != FROM && key != TO && key != REPLY_TO && key != SUBJECT) {
+            metaData.emplace(key, value);
+        }
     }
     return metaData;
-  }
+}
 
-  std::string Message::toString() const
-  {
+std::string Message::toString() const
+{
     std::string data;
     data += "\n=== METADATA ===\n";
-    for (auto& [key, value] : m_metadata)
-    {
-      data += "[" + key + "]=" + value + "\n";
+    for (auto& [key, value] : m_metadata) {
+        data += "[" + key + "]=" + value + "\n";
     }
     data += "=== USERDATA ===\n";
     data += m_data;
     data += "\n================";
 
     return data;
-  }
+}
 
-  Message& Message::operator=(const Message& other)
-  {
+Message& Message::operator=(const Message& other)
+{
     m_metadata = std::move(other.metaData());
-    m_data = std::move(other.userData());
+    m_data     = std::move(other.userData());
     return *this;
-  }
+}
 
 
-} //namespace fty::messagebus
+} // namespace fty::messagebus

--- a/common/src/utils.cpp
+++ b/common/src/utils.cpp
@@ -19,36 +19,35 @@
 
 #include <chrono>
 #include <ctime>
-
 #include <random>
 #include <string>
 #include <uuid/uuid.h>
 
-namespace fty::messagebus::utils
+namespace fty::messagebus::utils {
+
+const std::string generateUuid()
 {
-  const std::string generateUuid()
-  {
     uuid_t uuid;
     uuid_generate(uuid);
     char uuid_str[UUID_STR_LEN + 1];
     uuid_unparse_lower(uuid, uuid_str);
     return uuid_str;
-  }
+}
 
-  const std::string generateId()
-  {
-    std::random_device rd;
-    std::mt19937 rng(rd());
+const std::string generateId()
+{
+    std::random_device                 rd;
+    std::mt19937                       rng(rd());
     std::uniform_int_distribution<int> uni(0, RAND_MAX);
     return std::to_string(uni(rng));
-  }
+}
 
-  const std::string getClientId(const std::string& prefix)
-  {
-    std::chrono::milliseconds ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-      std::chrono::system_clock::now().time_since_epoch());
+const std::string getClientId(const std::string& prefix)
+{
+    std::chrono::milliseconds ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
     std::string clientId = prefix + "-" + std::to_string(ms.count());
     return clientId;
-  }
+}
 
 } // namespace fty::messagebus::utils

--- a/common/tests/MessageTest.cpp
+++ b/common/tests/MessageTest.cpp
@@ -1,24 +1,21 @@
-#include <fty/messagebus/Message.h>
-
 #include <catch2/catch.hpp>
+#include <fty/messagebus/Message.h>
 #include <iostream>
 
-namespace
-{
-  //----------------------------------------------------------------------
-  // Test case
-  //----------------------------------------------------------------------
-  using namespace fty::messagebus;
+//----------------------------------------------------------------------
+// Test case
+//----------------------------------------------------------------------
+using namespace fty::messagebus;
 
-  TEST_CASE("Build message", "[Message]")
-  {
+TEST_CASE("Build message", "[Message]")
+{
     Message msg = Message::buildMessage("FROM", "Q.TO", "TEST_SUBJECT", "data");
     REQUIRE(msg.isValidMessage());
     REQUIRE(!msg.needReply());
-  }
+}
 
-  TEST_CASE("Build request with reply", "[Message]")
-  {
+TEST_CASE("Build request with reply", "[Message]")
+{
     Message msg = Message::buildRequest("FROM", "Q.TO", "TEST_SUBJECT", "Q.REPLY", "data");
     REQUIRE(msg.isValidMessage());
     REQUIRE(msg.isRequest());
@@ -28,12 +25,12 @@ namespace
     REQUIRE(reply);
     REQUIRE(reply->isValidMessage());
     REQUIRE(!reply->needReply());
-  }
+}
 
-  TEST_CASE("Build wrong message", "[Message]")
-  {
-    Message request = Message::buildRequest("", "", "", "", "data");
-    auto replyData = request.userData() + "OK";
+TEST_CASE("Build wrong message", "[Message]")
+{
+    Message request   = Message::buildRequest("", "", "", "", "data");
+    auto    replyData = request.userData() + "OK";
 
     REQUIRE(request.buildReply(replyData).error() == "Not a valid message!");
     request.from("from");
@@ -46,10 +43,10 @@ namespace
     REQUIRE(request.buildReply(replyData));
 
     request.toString();
-  }
+}
 
-  TEST_CASE("Build message property", "[Message]")
-  {
+TEST_CASE("Build message property", "[Message]")
+{
     Message msg = Message::buildMessage("FROM", "Q.TO", "TEST_SUBJECT", "data", {{STATUS, "myStatus"}, {MESSAGE_ID, "123456"}});
     REQUIRE(msg.userData() == "data");
     REQUIRE(msg.status() == "myStatus");
@@ -58,6 +55,4 @@ namespace
     REQUIRE(msg.getMetaDataValue("TEST") == "test");
     msg.id("1234567");
     REQUIRE(msg.id() == "1234567");
-  }
-
 }

--- a/common/tests/utilsTest.cpp
+++ b/common/tests/utilsTest.cpp
@@ -1,18 +1,15 @@
+#include <catch2/catch.hpp>
 #include <fty/messagebus/utils.h>
 #include <fty/string-utils.h>
-
-#include <catch2/catch.hpp>
 #include <iostream>
 
-namespace
-{
-  //----------------------------------------------------------------------
-  // Test case
-  //----------------------------------------------------------------------
-  using namespace fty::messagebus::utils;
+//----------------------------------------------------------------------
+// Test case
+//----------------------------------------------------------------------
+using namespace fty::messagebus::utils;
 
-  TEST_CASE("Utils Uuid", "[utils]")
-  {
+TEST_CASE("Utils Uuid", "[utils]")
+{
     auto uuid = generateUuid();
     REQUIRE(uuid.size() == 36);
     auto vector = fty::split(uuid, "-");
@@ -22,20 +19,19 @@ namespace
     REQUIRE(vector.at(2).size() == 4);
     REQUIRE(vector.at(3).size() == 4);
     REQUIRE(vector.at(4).size() == 12);
-  }
+}
 
-  TEST_CASE("Utils id", "[utils]")
-  {
+TEST_CASE("Utils id", "[utils]")
+{
     auto id = generateId();
     REQUIRE(id.size() > 0);
-  }
+}
 
-  TEST_CASE("Utils clientId", "[utils]")
-  {
+TEST_CASE("Utils clientId", "[utils]")
+{
     auto clientId = getClientId("myPrefix");
-    auto vector = fty::split(clientId, "-");
+    auto vector   = fty::split(clientId, "-");
     REQUIRE(vector.size() == 2);
     REQUIRE(vector.at(0) == "myPrefix");
     REQUIRE(vector.at(1).size() == 13);
-  }
 }

--- a/mqtt/CMakeLists.txt
+++ b/mqtt/CMakeLists.txt
@@ -9,31 +9,27 @@ find_package(PahoMqttCpp REQUIRED)
 ##############################################################################################################
 
 etn_target(shared ${PROJECT_NAME} PUBLIC
-  SOURCES
-    src/*.cpp
-    src/*.h
-  PUBLIC_INCLUDE_DIR
-    public_include
-  PUBLIC_HEADERS
-    fty/messagebus/mqtt/MessageBusMqtt.h
-  USES_PUBLIC
-    fty-common-messagebus2
-  USES_PRIVATE
-    fty-common-messagebus-utils
-    fty_common_logging
-    paho-mqttpp3
-    paho-mqtt3as
-    paho-mqtt3c
-  FLAGS
-    "-fmax-errors=1"
+    SOURCES
+        src/*.cpp
+        src/*.h
+    PUBLIC_INCLUDE_DIR
+        public_include
+    PUBLIC_HEADERS
+        fty/messagebus/mqtt/MessageBusMqtt.h
+    USES_PUBLIC
+        fty-common-messagebus2
+    USES_PRIVATE
+        fty-common-messagebus-utils
+        fty_common_logging
+        paho-mqttpp3
+        paho-mqtt3as
+        paho-mqtt3c
 )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR})
 
 ## Tests
-if(BUILD_TESTING)
-  etn_test_target(${PROJECT_NAME}
+etn_test_target(${PROJECT_NAME}
     SOURCES
-      tests/*.cpp
+    tests/*.cpp
 )
-endif()

--- a/mqtt/public_include/fty/messagebus/mqtt/MessageBusMqtt.h
+++ b/mqtt/public_include/fty/messagebus/mqtt/MessageBusMqtt.h
@@ -25,36 +25,37 @@
 #include <fty/messagebus/MessageBus.h>
 #include <fty/messagebus/utils.h>
 
-namespace fty::messagebus::mqtt
+namespace fty::messagebus::mqtt {
+// Default mqtt end point
+static auto constexpr DEFAULT_ENDPOINT{"tcp://localhost:1883"};
+static auto constexpr BUS_IDENTITY{"MQTT"};
+
+static auto constexpr QOS{"QOS"};
+static auto constexpr RETAIN{"RETAIN"};
+
+class MsgBusMqtt;
+
+class MessageBusMqtt final : public fty::messagebus::MessageBus
 {
-  // Default mqtt end point
-  static auto constexpr DEFAULT_ENDPOINT{"tcp://localhost:1883"};
-  static auto constexpr BUS_IDENTITY{"MQTT"};
-
-  static auto constexpr QOS{"QOS"};
-  static auto constexpr RETAIN{"RETAIN"};
-
-  class MsgBusMqtt;
-
-  class MessageBusMqtt final : public fty::messagebus::MessageBus
-  {
-  public:
-    MessageBusMqtt( const ClientName& clientName = utils::getClientId("MessageBusMqtt"),
-                    const Endpoint& endpoint = DEFAULT_ENDPOINT,
-                    const Message& will = {});
+public:
+    MessageBusMqtt(
+        const ClientName& clientName = utils::getClientId("MessageBusMqtt"),
+        const Endpoint&   endpoint   = DEFAULT_ENDPOINT,
+        const Message&    will       = {});
 
     ~MessageBusMqtt() = default;
 
-    [[nodiscard]] fty::Expected<void> connect() noexcept override;
-    [[nodiscard]] fty::Expected<void> send(const Message& msg) noexcept override;
-    [[nodiscard]] fty::Expected<void> receive(const Address& address, MessageListener&& func, const std::string& filter = {}) noexcept override;
-    [[nodiscard]] fty::Expected<void> unreceive(const Address& address) noexcept override;
-    [[nodiscard]] fty::Expected<Message> request(const Message& msg, int timeOut) noexcept override;
+    [[nodiscard]] fty::Expected<void, ComState>      connect() noexcept override;
+    [[nodiscard]] fty::Expected<void, DeliveryState> send(const Message& msg) noexcept override;
+    [[nodiscard]] fty::Expected<void, DeliveryState> receive(
+        const Address& address, MessageListener&& func, const std::string& filter = {}) noexcept override;
+    [[nodiscard]] fty::Expected<void, DeliveryState>    unreceive(const Address& address) noexcept override;
+    [[nodiscard]] fty::Expected<Message, DeliveryState> request(const Message& msg, int timeOut) noexcept override;
 
-    [[nodiscard]] const ClientName & clientName() const noexcept override;
-    [[nodiscard]] const Identity & identity() const noexcept override;
+    [[nodiscard]] const ClientName& clientName() const noexcept override;
+    [[nodiscard]] const Identity&   identity() const noexcept override;
 
-  private:
+private:
     std::shared_ptr<MsgBusMqtt> m_busMqtt;
-  };
+};
 } // namespace fty::messagebus::mqtt

--- a/mqtt/src/CallBack.cpp
+++ b/mqtt/src/CallBack.cpp
@@ -28,146 +28,126 @@
 
 #include "CallBack.h"
 #include <fty/messagebus/Message.h>
-
 #include <fty_log.h>
-
 #include <mqtt/async_client.h>
 #include <mqtt/properties.h>
 
-namespace
+namespace {
+
+using namespace fty::messagebus;
+
+static MetaData getMetaDataFromMqttProperties(const ::mqtt::properties& props)
 {
-
-  using namespace fty::messagebus;
-
-  static auto getMetaDataFromMqttProperties(const ::mqtt::properties& props) -> const MetaData
-  {
 
     logDebug("getMetaDataFromMqttProperties...");
     auto metaData = MetaData{};
 
     // User properties
-    if (props.contains(::mqtt::property::USER_PROPERTY))
-    {
-      std::string key, value;
-      for (size_t i = 0; i < props.count(::mqtt::property::USER_PROPERTY); i++)
-      {
-        std::tie(key, value) = ::mqtt::get<::mqtt::string_pair>(props, ::mqtt::property::USER_PROPERTY, i);
-        metaData.emplace(key, value);
-      }
+    if (props.contains(::mqtt::property::USER_PROPERTY)) {
+        std::string key, value;
+        for (size_t i = 0; i < props.count(::mqtt::property::USER_PROPERTY); i++) {
+            std::tie(key, value) = ::mqtt::get<::mqtt::string_pair>(props, ::mqtt::property::USER_PROPERTY, i);
+            metaData.emplace(key, value);
+        }
     }
     // Req/Rep pattern properties
-    if (props.contains(::mqtt::property::CORRELATION_DATA))
-    {
-      metaData.emplace(CORRELATION_ID, ::mqtt::get<std::string>(props, ::mqtt::property::CORRELATION_DATA));
+    if (props.contains(::mqtt::property::CORRELATION_DATA)) {
+        metaData.emplace(CORRELATION_ID, ::mqtt::get<std::string>(props, ::mqtt::property::CORRELATION_DATA));
     }
 
-    if (props.contains(::mqtt::property::RESPONSE_TOPIC))
-    {
-      metaData.emplace(REPLY_TO, ::mqtt::get<std::string>(props, ::mqtt::property::RESPONSE_TOPIC));
+    if (props.contains(::mqtt::property::RESPONSE_TOPIC)) {
+        metaData.emplace(REPLY_TO, ::mqtt::get<std::string>(props, ::mqtt::property::RESPONSE_TOPIC));
     }
 
     logDebug("Done.");
     return metaData;
-  }
+}
 
 } // namespace
 
-namespace fty::messagebus::mqtt
-{
-  size_t NB_WORKERS = 16;
+namespace fty::messagebus::mqtt {
 
-  CallBack::CallBack()
+size_t NB_WORKERS = 16;
+
+CallBack::CallBack()
     : ::mqtt::callback()
-  {
+{
     m_poolWorkers = std::make_shared<utils::PoolWorker>(NB_WORKERS);
-  }
+}
 
-  // Callback called when connection lost.
-  void CallBack::connection_lost(const std::string& cause)
-  {
+// Callback called when connection lost.
+void CallBack::connection_lost(const std::string& cause)
+{
     std::string what = "?";
-    if (!cause.empty())
-    {
-      what = cause;
+    if (!cause.empty()) {
+        what = cause;
     }
     logError("Connection lost: {}", what);
-  }
+}
 
-  SubScriptionListener CallBack::subscriptions()
-  {
+SubScriptionListener CallBack::subscriptions()
+{
     return m_subscriptions;
-  }
+}
 
-  void CallBack::subscriptions(const std::string& topic, const MessageListener& messageListener)
-  {
-    if (auto it{m_subscriptions.find(topic)}; it == m_subscriptions.end())
-    {
-      m_subscriptions.emplace(topic, messageListener);
+void CallBack::subscriptions(const std::string& topic, const MessageListener& messageListener)
+{
+    if (auto it{m_subscriptions.find(topic)}; it == m_subscriptions.end()) {
+        m_subscriptions.emplace(topic, messageListener);
     }
-  }
+}
 
-  auto CallBack::subscribed(const std::string& topic) -> bool
-  {
+auto CallBack::subscribed(const std::string& topic) -> bool
+{
     bool isSubscript = false;
-    if (auto iter{m_subscriptions.find(topic)}; iter != m_subscriptions.end())
-    {
-      isSubscript = true;
+    if (auto iter{m_subscriptions.find(topic)}; iter != m_subscriptions.end()) {
+        isSubscript = true;
     }
     return isSubscript;
-  }
+}
 
-  void CallBack::eraseSubscriptions(const std::string& topic)
-  {
+void CallBack::eraseSubscriptions(const std::string& topic)
+{
     m_subscriptions.erase(topic);
-  }
+}
 
-  // Callback called when a mqtt message arrives.
-  void CallBack::onMessageArrived(::mqtt::const_message_ptr msg, AsynClientPointer clientPointer)
-  {
+// Callback called when a mqtt message arrives.
+void CallBack::onMessageArrived(::mqtt::const_message_ptr msg, AsynClientPointer clientPointer)
+{
     auto topic = msg->get_topic();
     logTrace("Message received from topic: '{}'", topic);
     // build metaData message from mqtt properties
     auto metaData = getMetaDataFromMqttProperties(msg->get_properties());
-    if (auto it{m_subscriptions.find(topic)}; it != m_subscriptions.end())
-    {
-      try
-      {
-        // Delegate to the pool worker
-        logTrace("Notify received from topic: '{}'", topic);
-        m_poolWorkers->offload([this, clientPointer, topic](MessageListener listener, const Message& mqttMsg) {
-          if (listener)
-          {
-            logTrace("Trigger callback...");
-            listener(mqttMsg);
-            logTrace("Trigger callback... Done.");
-          }
-          else
-          {
-            logTrace("No callback to trigger");
-          }
+    if (auto it{m_subscriptions.find(topic)}; it != m_subscriptions.end()) {
+        try {
+            // Delegate to the pool worker
+            logTrace("Notify received from topic: '{}'", topic);
+            m_poolWorkers->offload(
+                [this, clientPointer, topic](MessageListener listener, const Message& mqttMsg) {
+                    if (listener) {
+                        logTrace("Trigger callback...");
+                        listener(mqttMsg);
+                        logTrace("Trigger callback... Done.");
+                    } else {
+                        logTrace("No callback to trigger");
+                    }
 
-          // Unsubscribe only reply
-          auto iterator = mqttMsg.metaData().find(SUBJECT);
-          if (clientPointer && (iterator != mqttMsg.metaData().end()))
-          {
-            clientPointer->unsubscribe(topic);
-            this->eraseSubscriptions(topic);
-          }
-        },(it->second), Message{metaData, msg->get_payload_str()});
-      }
-      catch (const std::exception& e)
-      {
-        logError("Error in listener of queue '{}': '{}'", it->first, e.what());
-      }
-      catch (...)
-      {
-        logError("Error in listener of queue '{}': 'unknown error'", it->first);
-      }
+                    // Unsubscribe only reply
+                    auto iterator = mqttMsg.metaData().find(SUBJECT);
+                    if (clientPointer && (iterator != mqttMsg.metaData().end())) {
+                        clientPointer->unsubscribe(topic);
+                        this->eraseSubscriptions(topic);
+                    }
+                },
+                (it->second), Message{metaData, msg->get_payload_str()});
+        } catch (const std::exception& e) {
+            logError("Error in listener of queue '{}': '{}'", it->first, e.what());
+        } catch (...) {
+            logError("Error in listener of queue '{}': 'unknown error'", it->first);
+        }
+    } else {
+        logWarn("Message skipped for {}", topic);
     }
-    else
-    {
-      logWarn("Message skipped for {}", topic);
-    }
-  }
+}
 
 } // namespace fty::messagebus::mqtt

--- a/mqtt/src/CallBack.h
+++ b/mqtt/src/CallBack.h
@@ -24,39 +24,37 @@
 #include <fty/messagebus/Message.h>
 #include <fty/messagebus/MessageBus.h>
 #include <fty/messagebus/utils/MsgBusPoolWorker.hpp>
-
 #include <map>
 #include <mqtt/async_client.h>
 #include <mqtt/client.h>
 #include <string>
 #include <thread>
 
-namespace fty::messagebus::mqtt
+namespace fty::messagebus::mqtt {
+
+using AsynClientPointer    = std::shared_ptr<::mqtt::async_client>;
+using SynClientPointer     = std::shared_ptr<::mqtt::client>;
+using MessageListener      = fty::messagebus::MessageListener;
+using SubScriptionListener = std::map<std::string, MessageListener>;
+
+using PoolWorkerPointer = std::shared_ptr<utils::PoolWorker>;
+
+class CallBack : public ::mqtt::callback
 {
-
-  using AsynClientPointer = std::shared_ptr<::mqtt::async_client>;
-  using SynClientPointer = std::shared_ptr<::mqtt::client>;
-  using MessageListener = fty::messagebus::MessageListener;
-  using SubScriptionListener = std::map<std::string, MessageListener>;
-
-  using PoolWorkerPointer = std::shared_ptr<utils::PoolWorker>;
-
-  class CallBack : public ::mqtt::callback
-  {
-  public:
+public:
     CallBack();
     ~CallBack() = default;
     void connection_lost(const std::string& cause) override;
     void onMessageArrived(::mqtt::const_message_ptr msg, AsynClientPointer clientPointer = nullptr);
 
     SubScriptionListener subscriptions();
-    void subscriptions(const std::string& topic, const MessageListener& messageListener);
-    bool subscribed(const std::string& topic);
-    void eraseSubscriptions(const std::string& topic);
+    void                 subscriptions(const std::string& topic, const MessageListener& messageListener);
+    bool                 subscribed(const std::string& topic);
+    void                 eraseSubscriptions(const std::string& topic);
 
-  private:
+private:
     SubScriptionListener m_subscriptions;
-    PoolWorkerPointer m_poolWorkers;
-  };
+    PoolWorkerPointer    m_poolWorkers;
+};
 
 } // namespace fty::messagebus::mqtt

--- a/mqtt/src/MessageBusMqtt.cpp
+++ b/mqtt/src/MessageBusMqtt.cpp
@@ -18,77 +18,71 @@
 */
 
 #include "fty/messagebus/mqtt/MessageBusMqtt.h"
-#include <fty/messagebus/MessageBusStatus.h>
-
 #include "CallBack.h"
 #include "MsgBusMqtt.h"
-
+#include <fty/expected.h>
+#include <fty/messagebus/MessageBusStatus.h>
+#include <fty_log.h>
+#include <memory>
 #include <mqtt/async_client.h>
 #include <mqtt/client.h>
 #include <mqtt/message.h>
 #include <mqtt/properties.h>
 
-#include <fty/expected.h>
-#include <fty_log.h>
+namespace fty::messagebus::mqtt {
 
-#include <memory>
-
-namespace fty::messagebus::mqtt
-{
-  MessageBusMqtt::MessageBusMqtt(const ClientName& clientName,
-                                 const Endpoint& endpoint,
-                                 const Message& will)
+MessageBusMqtt::MessageBusMqtt(const ClientName& clientName, const Endpoint& endpoint, const Message& will)
     : MessageBus()
-  {
+{
     m_busMqtt = std::make_shared<MsgBusMqtt>(clientName, endpoint, will);
-  }
+}
 
-  fty::Expected<void> MessageBusMqtt::connect() noexcept
-  {
+fty::Expected<void, ComState> MessageBusMqtt::connect() noexcept
+{
     return m_busMqtt->connect();
-  }
+}
 
-  fty::Expected<void> MessageBusMqtt::send(const Message& msg) noexcept
-  {
-    if (!msg.isValidMessage())
-    {
-      return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_REJECTED));
+fty::Expected<void, DeliveryState> MessageBusMqtt::send(const Message& msg) noexcept
+{
+    if (!msg.isValidMessage()) {
+        return fty::unexpected(DeliveryState::Rejected);
     }
     return m_busMqtt->send(msg);
-  }
+}
 
-  fty::Expected<void> MessageBusMqtt::receive(const Address& address, MessageListener&& func, const std::string& /*filter*/) noexcept
-  {
+fty::Expected<void, DeliveryState> MessageBusMqtt::receive(
+    const Address& address, MessageListener&& func, const std::string& /*filter*/) noexcept
+{
     return m_busMqtt->receive(address, func);
-  }
+}
 
-  fty::Expected<void> MessageBusMqtt::unreceive(const Address& address) noexcept
-  {
+fty::Expected<void, DeliveryState> MessageBusMqtt::unreceive(const Address& address) noexcept
+{
     return m_busMqtt->unreceive(address);
-  }
+}
 
-  fty::Expected<Message> MessageBusMqtt::request(const Message& msg, int timeOut) noexcept
-  {
-    //Sanity check
+fty::Expected<Message, DeliveryState> MessageBusMqtt::request(const Message& msg, int timeOut) noexcept
+{
+    // Sanity check
     if (!msg.isValidMessage())
-      return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_REJECTED));
+        return fty::unexpected(DeliveryState::Rejected);
     if (!msg.needReply())
-      return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_REJECTED));
+        return fty::unexpected(DeliveryState::Rejected);
 
     // Sendrequest
     return m_busMqtt->request(msg, timeOut);
-  }
+}
 
-  const std::string& MessageBusMqtt::clientName() const noexcept
-  {
+const std::string& MessageBusMqtt::clientName() const noexcept
+{
     return m_busMqtt->clientName();
-  }
+}
 
-  static const std::string g_identity(BUS_IDENTITY);
+static const std::string g_identity(BUS_IDENTITY);
 
-  const std::string& MessageBusMqtt::identity() const noexcept
-  {
+const std::string& MessageBusMqtt::identity() const noexcept
+{
     return g_identity;
-  }
+}
 
 } // namespace fty::messagebus::mqtt

--- a/mqtt/src/MsgBusMqtt.cpp
+++ b/mqtt/src/MsgBusMqtt.cpp
@@ -18,119 +18,103 @@
 */
 
 #include "MsgBusMqtt.h"
-
 #include <fty/messagebus/MessageBusStatus.h>
 #include <fty/messagebus/mqtt/MessageBusMqtt.h>
 #include <fty/messagebus/utils.h>
 #include <fty_log.h>
-
 #include <mqtt/async_client.h>
 #include <mqtt/client.h>
 #include <mqtt/message.h>
 #include <mqtt/properties.h>
 
-namespace fty::messagebus::mqtt
+namespace fty::messagebus::mqtt {
+
+using duration = int64_t;
+
+duration KEEP_ALIVE           = 20;
+static auto constexpr _QOS    = ::mqtt::ReasonCode::GRANTED_QOS_2;
+auto constexpr TIMEOUT        = std::chrono::seconds(5);
+auto constexpr DOUBLE_TIMEOUT = std::chrono::seconds(10);
+
+static const MetaData getMetaDataFromMqttProperties(const ::mqtt::properties& props)
 {
-  using namespace fty::messagebus;
-  using duration = int64_t;
-
-  duration KEEP_ALIVE = 20;
-  static auto constexpr _QOS = ::mqtt::ReasonCode::GRANTED_QOS_2;
-  auto constexpr TIMEOUT = std::chrono::seconds(5);
-  auto constexpr DOUBLE_TIMEOUT = std::chrono::seconds(10);
-
-  static const MetaData getMetaDataFromMqttProperties(const ::mqtt::properties& props)
-  {
     Message message;
 
     // User properties
-    if (props.contains(::mqtt::property::USER_PROPERTY))
-    {
-      std::string key, value;
-      for (size_t i = 0; i < props.count(::mqtt::property::USER_PROPERTY); ++i)
-      {
-        std::tie(key, value) = ::mqtt::get<::mqtt::string_pair>(props, ::mqtt::property::USER_PROPERTY, i);
-        message.setMetaDataValue(key, value);
-      }
+    if (props.contains(::mqtt::property::USER_PROPERTY)) {
+        std::string key, value;
+        for (size_t i = 0; i < props.count(::mqtt::property::USER_PROPERTY); ++i) {
+            std::tie(key, value) = ::mqtt::get<::mqtt::string_pair>(props, ::mqtt::property::USER_PROPERTY, i);
+            message.setMetaDataValue(key, value);
+        }
     }
     // Req/Rep pattern properties
-    if (props.contains(::mqtt::property::CORRELATION_DATA))
-    {
-      message.correlationId(::mqtt::get<std::string>(props, ::mqtt::property::CORRELATION_DATA));
+    if (props.contains(::mqtt::property::CORRELATION_DATA)) {
+        message.correlationId(::mqtt::get<std::string>(props, ::mqtt::property::CORRELATION_DATA));
     }
 
-    if (props.contains(::mqtt::property::RESPONSE_TOPIC))
-    {
-      message.replyTo(::mqtt::get<std::string>(props, ::mqtt::property::RESPONSE_TOPIC));
+    if (props.contains(::mqtt::property::RESPONSE_TOPIC)) {
+        message.replyTo(::mqtt::get<std::string>(props, ::mqtt::property::RESPONSE_TOPIC));
     }
     return message.metaData();
-  }
+}
 
-  static const ::mqtt::properties getMqttProperties(const Message& message)
-  {
+static const ::mqtt::properties getMqttProperties(const Message& message)
+{
     auto props = ::mqtt::properties{};
-    for (const auto& [key, value] : message.metaData())
-    {
-      if (key == REPLY_TO)
-      {
-        props.add({::mqtt::property::CORRELATION_DATA, message.correlationId()});
-        props.add({::mqtt::property::RESPONSE_TOPIC, message.replyTo()});
-      }
-      else if (key != CORRELATION_ID)
-      {
-        props.add({::mqtt::property::USER_PROPERTY, key, value});
-      }
+    for (const auto& [key, value] : message.metaData()) {
+        if (key == REPLY_TO) {
+            props.add({::mqtt::property::CORRELATION_DATA, message.correlationId()});
+            props.add({::mqtt::property::RESPONSE_TOPIC, message.replyTo()});
+        } else if (key != CORRELATION_ID) {
+            props.add({::mqtt::property::USER_PROPERTY, key, value});
+        }
     }
     return props;
-  }
+}
 
-  static ::mqtt::message_ptr buildMessageForMqtt(const Message& message)
-  {
+static ::mqtt::message_ptr buildMessageForMqtt(const Message& message)
+{
     // Adding all meta data inside mqtt properties
     auto props = getMqttProperties(message);
 
-    //get retain
+    // get retain
     bool retain = (message.getMetaDataValue(mqtt::RETAIN) == "true");
 
-    //get QoS
+    // get QoS
     ::mqtt::ReasonCode QoS = ::mqtt::ReasonCode::GRANTED_QOS_2;
-    if (message.getMetaDataValue(mqtt::QOS) == "1")
-    {
-      QoS = ::mqtt::ReasonCode::GRANTED_QOS_1;
-    }
-    else if (message.getMetaDataValue(mqtt::QOS) == "0")
-    {
-      QoS = ::mqtt::ReasonCode::GRANTED_QOS_0;
+    if (message.getMetaDataValue(mqtt::QOS) == "1") {
+        QoS = ::mqtt::ReasonCode::GRANTED_QOS_1;
+    } else if (message.getMetaDataValue(mqtt::QOS) == "0") {
+        QoS = ::mqtt::ReasonCode::GRANTED_QOS_0;
     }
 
     auto msgToSend = ::mqtt::message_ptr_builder()
-                       .topic(message.to())
-                       .payload(message.userData())
-                       .qos(QoS)
-                       .properties(props)
-                       .retained(retain)
-                       .finalize();
+                         .topic(message.to())
+                         .payload(message.userData())
+                         .qos(QoS)
+                         .properties(props)
+                         .retained(retain)
+                         .finalize();
     return msgToSend;
-  }
+}
 
-  MsgBusMqtt::~MsgBusMqtt()
-  {
+MsgBusMqtt::~MsgBusMqtt()
+{
     // Cleaning all async/sync mqtt clients
-    if (m_asynClient)
-    {
-      logDebug("Asynchronous client cleaning ...");
-      m_asynClient->disable_callbacks();
-      m_asynClient->stop_consuming();
-      if (m_asynClient->is_connected())
-      {
-        m_asynClient->disconnect()->wait();
-      }
-      logDebug("Asynchronous client cleaned");
+    if (m_asynClient) {
+        logDebug("Asynchronous client cleaning ...");
+        m_asynClient->disable_callbacks();
+        m_asynClient->stop_consuming();
+        if (m_asynClient->is_connected()) {
+            m_asynClient->disconnect()->wait();
+        }
+        logDebug("Asynchronous client cleaned");
     }
-  }
+}
 
-  fty::Expected<void> MsgBusMqtt::connect()
-  {
+fty::Expected<void, ComState> MsgBusMqtt::connect()
+{
     logDebug("Connecting for {} to {} ...", m_clientName, m_endpoint);
     ::mqtt::create_options opts(MQTTVERSION_5);
 
@@ -138,176 +122,154 @@ namespace fty::messagebus::mqtt
 
     // Connection options
     ::mqtt::connect_options connOpts = ::mqtt::connect_options_builder()
-                                         .clean_session(false)
-                                         .mqtt_version(MQTTVERSION_5)
-                                         .keep_alive_interval(std::chrono::seconds(KEEP_ALIVE))
-                                         .connect_timeout(TIMEOUT)
-                                         .automatic_reconnect(TIMEOUT, DOUBLE_TIMEOUT)
-                                         .clean_start(true)
-                                         .finalize();
+                                           .clean_session(false)
+                                           .mqtt_version(MQTTVERSION_5)
+                                           .keep_alive_interval(std::chrono::seconds(KEEP_ALIVE))
+                                           .connect_timeout(TIMEOUT)
+                                           .automatic_reconnect(TIMEOUT, DOUBLE_TIMEOUT)
+                                           .clean_start(true)
+                                           .finalize();
 
-    if (m_will.isValidMessage())
-    {
-      ::mqtt::will_options willOptions(*buildMessageForMqtt(m_will));
-      connOpts.set_will(willOptions);
+    if (m_will.isValidMessage()) {
+        ::mqtt::will_options willOptions(*buildMessageForMqtt(m_will));
+        connOpts.set_will(willOptions);
     }
 
-    try
-    {
-      // Start consuming _before_ connecting, because we could get a flood
-      // of stored messages as soon as the connection completes since
-      // we're using a persistent (non-clean) session with the broker.
-      m_asynClient->start_consuming();
-      m_asynClient->connect(connOpts)->wait();
+    try {
+        // Start consuming _before_ connecting, because we could get a flood
+        // of stored messages as soon as the connection completes since
+        // we're using a persistent (non-clean) session with the broker.
+        m_asynClient->start_consuming();
+        m_asynClient->connect(connOpts)->wait();
 
-      // Called after a reconnection
-      m_asynClient->set_connected_handler([this](const std::string& cause) {
+        // Called after a reconnection
+        m_asynClient->set_connected_handler([this](const std::string& cause) {
+            (cause.empty()) ? logDebug("Connected") : logDebug("{}", cause);
+            // Refresh all recieved
+            for (auto [address, listener] : m_cb.subscriptions()) {
+                auto received = receive(address, listener);
+                if (!received) {
+                    logWarn("Address '{}' rejected after reconnection", address);
+                }
+            }
+        });
 
-        (cause.empty()) ? logDebug("Connected") : logDebug("{}", cause);
-        // Refresh all recieved
-        for (auto [address, listener] : m_cb.subscriptions())
-        {
-          auto received = receive(address, listener);
-          if (!received)
-          {
-            logWarn("Address '{}' rejected after reconnection", address);
-          }
-        }
-      });
+        // After a connection lost, depending of reconnection setting, this handler is called by paho library
+        m_asynClient->set_update_connection_handler([this](const ::mqtt::connect_data& /*connData*/) {
+            if (!m_asynClient->is_connected()) {
+                logInfo("Try a reconnection with {} ...", m_endpoint);
+                m_asynClient->reconnect()->wait_for(TIMEOUT);
+            }
+            return true;
+        });
 
-      // After a connection lost, depending of reconnection setting, this handler is called by paho library
-      m_asynClient->set_update_connection_handler([this](const ::mqtt::connect_data& /*connData*/) {
-        if (!m_asynClient->is_connected())
-        {
-          logInfo("Try a reconnection with {} ...", m_endpoint);
-          m_asynClient->reconnect()->wait_for(TIMEOUT);
-        }
-        return true;
-      });
-
-      // Callback(s)
-      m_asynClient->set_callback(m_cb);
-      logInfo("{} => connect status: async client: {}", m_clientName.c_str(), m_asynClient->is_connected() ? "true" : "false");
-    }
-    catch (const ::mqtt::exception& e)
-    {
-      logError("Error to connect with the Mqtt server, reason: {}", e.get_message().c_str());
-      return fty::unexpected(to_string(ComState::COM_STATE_CONNECT_FAILED));
-    }
-    catch (const std::exception& e)
-    {
-      logError("unexpected error: {}", e.what());
-      return fty::unexpected(to_string(ComState::COM_STATE_CONNECT_FAILED));
+        // Callback(s)
+        m_asynClient->set_callback(m_cb);
+        logInfo("{} => connect status: async client: {}", m_clientName.c_str(), m_asynClient->is_connected() ? "true" : "false");
+    } catch (const ::mqtt::exception& e) {
+        logError("Error to connect with the Mqtt server, reason: {}", e.get_message().c_str());
+        return fty::unexpected(ComState::ConnectFailed);
+    } catch (const std::exception& e) {
+        logError("unexpected error: {}", e.what());
+        return fty::unexpected(ComState::ConnectFailed);
     }
 
     return {};
-  }
+}
 
-  fty::Expected<void> MsgBusMqtt::receive(const Address& address, MessageListener messageListener)
-  {
-    if (!isServiceAvailable())
-    {
-      logError("Service not available");
-      return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_UNAVAILABLE));
+fty::Expected<void, DeliveryState> MsgBusMqtt::receive(const Address& address, MessageListener messageListener)
+{
+    if (!isServiceAvailable()) {
+        logError("Service not available");
+        return fty::unexpected(DeliveryState::Unavailable);
     }
 
-    if (!m_cb.subscribed(address))
-    {
-      m_cb.subscriptions(address, messageListener);
-      m_asynClient->set_message_callback([this](::mqtt::const_message_ptr msg) {
-        // Wrapper from mqtt msg to Message
-        m_cb.onMessageArrived(msg);
-      });
+    if (!m_cb.subscribed(address)) {
+        m_cb.subscriptions(address, messageListener);
+        m_asynClient->set_message_callback([this](::mqtt::const_message_ptr msg) {
+            // Wrapper from mqtt msg to Message
+            m_cb.onMessageArrived(msg);
+        });
 
-      if (!m_asynClient->subscribe(address, _QOS)->wait_for(TIMEOUT))
-      {
-        logError("Receive for {} (Rejected)", address);
-        return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_REJECTED));
-      }
-    }
-    else
-    {
-      // Here after a reconnection
-      m_asynClient->subscribe(address, _QOS)->wait_for(TIMEOUT);
+        if (!m_asynClient->subscribe(address, _QOS)->wait_for(TIMEOUT)) {
+            logError("Receive for {} (Rejected)", address);
+            return fty::unexpected(DeliveryState::Rejected);
+        }
+    } else {
+        // Here after a reconnection
+        m_asynClient->subscribe(address, _QOS)->wait_for(TIMEOUT);
     }
 
     logDebug("Waiting to receive msg from: {} Accepted", address);
     return {};
-  }
+}
 
-  fty::Expected<void> MsgBusMqtt::unreceive(const Address& address)
-  {
-    if (!isServiceAvailable())
-    {
-      logError("Service not available");
-      return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_UNAVAILABLE));
+fty::Expected<void, DeliveryState> MsgBusMqtt::unreceive(const Address& address)
+{
+    if (!isServiceAvailable()) {
+        logError("Service not available");
+        return fty::unexpected(DeliveryState::Unavailable);
     }
 
-    if (!m_cb.subscribed(address))
-    {
-      logError("Address not found {}, unsubscribed (Rejected)", address);
-      return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_REJECTED));
+    if (!m_cb.subscribed(address)) {
+        logError("Address not found {}, unsubscribed (Rejected)", address);
+        return fty::unexpected(DeliveryState::Rejected);
     }
 
     m_asynClient->unsubscribe(address)->wait_for(TIMEOUT);
     m_cb.eraseSubscriptions(address);
     logDebug("Unreceive for {} Accepted", address);
     return {};
-  }
+}
 
-  fty::Expected<void> MsgBusMqtt::send(const Message& message)
-  {
-    if (!isServiceAvailable())
-    {
-      logError("Service not available");
-      return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_UNAVAILABLE));
+fty::Expected<void, DeliveryState> MsgBusMqtt::send(const Message& message)
+{
+    if (!isServiceAvailable()) {
+        logError("Service not available");
+        return fty::unexpected(DeliveryState::Unavailable);
     }
 
     logDebug("Sending message {}", message.toString());
 
     auto msgToSend = buildMessageForMqtt(message);
 
-    if (!m_asynClient->publish(msgToSend)->wait_for(TIMEOUT))
-    {
-      logError("Message sent (Rejected)");
-      return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_REJECTED));
+    if (!m_asynClient->publish(msgToSend)->wait_for(TIMEOUT)) {
+        logError("Message sent (Rejected)");
+        return fty::unexpected(DeliveryState::Rejected);
     }
 
     logDebug("Message sent (Accepted)");
     return {};
-  }
+}
 
-  fty::Expected<Message> MsgBusMqtt::request(const Message& message, int receiveTimeOut)
-  {
-    if (!isServiceAvailable())
-    {
-      logError("Service not available");
-      return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_UNAVAILABLE));
+fty::Expected<Message, DeliveryState> MsgBusMqtt::request(const Message& message, int receiveTimeOut)
+{
+    if (!isServiceAvailable()) {
+        logError("Service not available");
+        return fty::unexpected(DeliveryState::Unavailable);
     }
 
     ::mqtt::const_message_ptr msg;
     m_asynClient->subscribe(message.replyTo(), _QOS);
     auto msgSent = send(message);
-    if (!msgSent)
-    {
-      return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_REJECTED));
+    if (!msgSent) {
+        return fty::unexpected(DeliveryState::Rejected);
     }
 
     auto messageArrived = m_asynClient->try_consume_message_for(&msg, std::chrono::seconds(receiveTimeOut));
     m_asynClient->unsubscribe(message.replyTo());
-    if (!messageArrived)
-    {
-      logError("No message arrive in time!");
-      return fty::unexpected(to_string(DeliveryState::DELIVERY_STATE_TIMEOUT));
+    if (!messageArrived) {
+        logError("No message arrive in time!");
+        return fty::unexpected(DeliveryState::Timeout);
     }
 
     logDebug("Message arrived ({})", msg->get_payload_str().c_str());
     return Message(getMetaDataFromMqttProperties(msg->get_properties()), msg->get_payload_str());
-  }
+}
 
-  bool MsgBusMqtt::isServiceAvailable()
-  {
+bool MsgBusMqtt::isServiceAvailable()
+{
     return m_asynClient && m_asynClient->is_connected();
-  }
+}
 
 } // namespace fty::messagebus::mqtt

--- a/mqtt/src/MsgBusMqtt.h
+++ b/mqtt/src/MsgBusMqtt.h
@@ -21,51 +21,49 @@
 
 #include "CallBack.h"
 
-namespace fty::messagebus::mqtt
+namespace fty::messagebus::mqtt {
+class MsgBusMqtt
 {
-  class MsgBusMqtt
-  {
-  public:
-
+public:
     MsgBusMqtt(const std::string& clientName, const Endpoint& endpoint, const Message& will = Message())
-      : m_clientName(clientName)
-      , m_endpoint(endpoint)
-      , m_will(will) {};
+        : m_clientName(clientName)
+        , m_endpoint(endpoint)
+        , m_will(will){};
 
     MsgBusMqtt() = delete;
     ~MsgBusMqtt();
 
     MsgBusMqtt(MsgBusMqtt&&) = delete;
     MsgBusMqtt& operator=(MsgBusMqtt&&) = delete;
-    MsgBusMqtt(const MsgBusMqtt&) = delete;
+    MsgBusMqtt(const MsgBusMqtt&)       = delete;
     MsgBusMqtt& operator=(const MsgBusMqtt&) = delete;
 
-    [[nodiscard]] fty::Expected<void> connect();
+    [[nodiscard]] fty::Expected<void, ComState> connect();
 
-    [[nodiscard]] fty::Expected<void> receive(const Address& address, MessageListener messageListener);
-    [[nodiscard]] fty::Expected<void> unreceive(const Address& address);
-    [[nodiscard]] fty::Expected<void> send(const Message& message);
+    [[nodiscard]] fty::Expected<void, DeliveryState> receive(const Address& address, MessageListener messageListener);
+    [[nodiscard]] fty::Expected<void, DeliveryState> unreceive(const Address& address);
+    [[nodiscard]] fty::Expected<void, DeliveryState> send(const Message& message);
 
     // Sync request with timeout
-    [[nodiscard]] fty::Expected<Message> request(const Message& message, int receiveTimeOut);
+    [[nodiscard]] fty::Expected<Message, DeliveryState> request(const Message& message, int receiveTimeOut);
 
     const std::string& clientName() const
     {
-      return m_clientName;
+        return m_clientName;
     }
 
     bool isServiceAvailable();
 
-  private:
+private:
     std::string m_clientName;
-    Endpoint m_endpoint;
-    Message m_will;
+    Endpoint    m_endpoint;
+    Message     m_will;
 
     // Asynchronous and synchronous mqtt client
     AsynClientPointer m_asynClient;
-    SynClientPointer m_synClient;
+    SynClientPointer  m_synClient;
 
     // Call back
     CallBack m_cb;
-  };
+};
 } // namespace fty::messagebus::mqtt

--- a/mqtt/tests/MessageBusMqttTest.cpp
+++ b/mqtt/tests/MessageBusMqttTest.cpp
@@ -17,303 +17,299 @@
     =========================================================================
 */
 
+#include <catch2/catch.hpp>
 #include <fty/messagebus/Message.h>
 #include <fty/messagebus/MessageBusStatus.h>
 #include <fty/messagebus/mqtt/MessageBusMqtt.h>
-
-#include <catch2/catch.hpp>
 #include <iostream>
-
 #include <mutex>
 #include <thread>
 
-namespace
-{
-  // NOTE: This test case requires network access. It uses one of
-  // the public available MQTT brokers
+namespace {
+
+// NOTE: This test case requires network access. It uses one of
+// the public available MQTT brokers
 #if defined(EXTERNAL_SERVER_FOR_TEST)
-  static constexpr auto MQTT_SERVER_URI{"tcp://mqtt.eclipse.org:1883"};
+static constexpr auto MQTT_SERVER_URI{"tcp://mqtt.eclipse.org:1883"};
 #else
-  static constexpr auto MQTT_SERVER_URI{"tcp://localhost:1883"};
+static constexpr auto MQTT_SERVER_URI{"tcp://localhost:1883"};
 #endif
 
-  using namespace fty::messagebus;
+using namespace fty::messagebus;
 
-  auto constexpr TIMEOUT = std::chrono::seconds(2);
-  static const std::string QUERY = "query";
-  static const std::string QUERY_2 = "query2";
-  static const std::string OK = ":OK";
-  static const std::string QUERY_AND_OK = QUERY + OK;
-  static const std::string RESPONSE_2 = QUERY_2 + OK;
+auto constexpr TIMEOUT                = std::chrono::seconds(2);
+static const std::string QUERY        = "query";
+static const std::string QUERY_2      = "query2";
+static const std::string OK           = ":OK";
+static const std::string QUERY_AND_OK = QUERY + OK;
+static const std::string RESPONSE_2   = QUERY_2 + OK;
 
-  // Mutex
-  std::mutex m_lock;
+// Mutex
+std::mutex m_lock;
 
-  struct MsgReceived
-  {
+struct MsgReceived
+{
     int receiver;
     int replyer;
 
     MsgReceived()
-      : receiver(0)
-      , replyer(0)
+        : receiver(0)
+        , replyer(0)
     {
     }
 
     void reset()
     {
-      std::lock_guard<std::mutex> lock(m_lock);
-      receiver = 0;
-      replyer = 0;
+        std::lock_guard<std::mutex> lock(m_lock);
+        receiver = 0;
+        replyer  = 0;
     }
 
     void incReceiver()
     {
-      std::lock_guard<std::mutex> lock(m_lock);
-      receiver++;
+        std::lock_guard<std::mutex> lock(m_lock);
+        receiver++;
     }
 
     void incReplyer()
     {
-      std::lock_guard<std::mutex> lock(m_lock);
-      replyer++;
+        std::lock_guard<std::mutex> lock(m_lock);
+        replyer++;
     }
 
     bool assertValue(const int expected)
     {
-      return (receiver == expected && replyer == expected);
+        return (receiver == expected && replyer == expected);
     }
 
     bool isRecieved(const int expected)
     {
-      return (receiver == expected);
+        return (receiver == expected);
     }
-  };
+};
 
-  auto g_msgRecieved = MsgReceived();
+auto g_msgRecieved = MsgReceived();
 
-  void replyerAddOK(const Message& message)
-  {
+void replyerAddOK(const Message& message)
+{
     g_msgRecieved.incReplyer();
-    //Build the response
+    // Build the response
     auto response = message.buildReply(message.userData() + OK);
 
-    if (!response)
-    {
-      std::cerr << response.error() << std::endl;
+    if (!response) {
+        std::cerr << response.error() << std::endl;
     }
 
-    //send the response
+    // send the response
     auto msgBus = mqtt::MessageBusMqtt("TestCase", MQTT_SERVER_URI);
-    auto connected = msgBus.connect();
+    REQUIRE(msgBus.connect());
     auto msgSent = msgBus.send(response.value());
-    if (!msgSent)
-    {
-      std::cerr << msgSent.error() << std::endl;
+    if (!msgSent) {
+        FAIL(to_string(msgSent.error()));
     }
-  }
+}
 
-  // message listener
-  void messageListener(const Message& /*message*/)
-  {
+// message listener
+void messageListener(const Message& /*message*/)
+{
     g_msgRecieved.incReceiver();
-  }
+}
 
-  //----------------------------------------------------------------------
-  // Test case
-  //----------------------------------------------------------------------
+//----------------------------------------------------------------------
+// Test case
+//----------------------------------------------------------------------
 
-  TEST_CASE("Identity", "[identity]")
-  {
+TEST_CASE("Identity", "[identity]")
+{
     auto msgBus = mqtt::MessageBusMqtt("IdentitytestCase", MQTT_SERVER_URI);
     REQUIRE(msgBus.clientName() == "IdentitytestCase");
     REQUIRE(msgBus.identity() == mqtt::BUS_IDENTITY);
-  }
+}
 
-  TEST_CASE("queue", "[mqtt][request]")
-  {
+TEST_CASE("queue", "[mqtt][request]")
+{
     SECTION("Send")
     {
-      std::string sendTestQueue = "/test/message/send";
-      auto msgBus = mqtt::MessageBusMqtt("MessageRecieverSendTestCase", MQTT_SERVER_URI);
-      REQUIRE(msgBus.connect());
+        std::string sendTestQueue = "/test/message/send";
+        auto        msgBus        = mqtt::MessageBusMqtt("MessageRecieverSendTestCase", MQTT_SERVER_URI);
+        REQUIRE(msgBus.connect());
 
-      auto msgBusSender = mqtt::MessageBusMqtt("MessageSenderSendTestCase", MQTT_SERVER_URI);
-      REQUIRE(msgBusSender.connect());
+        auto msgBusSender = mqtt::MessageBusMqtt("MessageSenderSendTestCase", MQTT_SERVER_URI);
+        REQUIRE(msgBusSender.connect());
 
-      REQUIRE(msgBusSender.receive(sendTestQueue, messageListener));
+        REQUIRE(msgBusSender.receive(sendTestQueue, messageListener));
 
-      // Send synchronous request
-      Message msg = Message::buildMessage("MqttMessageTestCase", sendTestQueue, "TEST", QUERY);
+        // Send synchronous request
+        Message msg = Message::buildMessage("MqttMessageTestCase", sendTestQueue, "TEST", QUERY);
 
-      g_msgRecieved.reset();
-      int nbMessageToSend = 3;
-      for (int i = 0; i < nbMessageToSend; i++)
-      {
-        REQUIRE(msgBusSender.send(msg));
-      }
-      std::this_thread::sleep_for(TIMEOUT);
-      CHECK(g_msgRecieved.isRecieved(nbMessageToSend));
+        g_msgRecieved.reset();
+        int nbMessageToSend = 3;
+        for (int i = 0; i < nbMessageToSend; i++) {
+            REQUIRE(msgBusSender.send(msg));
+        }
+        std::this_thread::sleep_for(TIMEOUT);
+        CHECK(g_msgRecieved.isRecieved(nbMessageToSend));
     }
 
     SECTION("Send sync request")
     {
-      std::string syncTestQueue = "/etn/test/message/sync/";
+        std::string syncTestQueue = "/etn/test/message/sync/";
 
-      auto msgBusReciever = mqtt::MessageBusMqtt("SyncReceiverTestCase", MQTT_SERVER_URI);
+        auto msgBusReciever = mqtt::MessageBusMqtt("SyncReceiverTestCase", MQTT_SERVER_URI);
 
-      // Send synchronous request
-      Message request = Message::buildRequest("SyncRequesterTestCase", syncTestQueue + "request", "SyncTest", syncTestQueue + "reply", QUERY);
+        // Send synchronous request
+        Message request =
+            Message::buildRequest("SyncRequesterTestCase", syncTestQueue + "request", "SyncTest", syncTestQueue + "reply", QUERY);
 
-      REQUIRE(msgBusReciever.connect());
-      REQUIRE(msgBusReciever.receive(request.to(), replyerAddOK));
+        REQUIRE(msgBusReciever.connect());
+        REQUIRE(msgBusReciever.receive(request.to(), replyerAddOK));
 
-      // Test without connection before.
-      auto msgBusRequester = mqtt::MessageBusMqtt("SyncRequesterTestCase", MQTT_SERVER_URI);
-      auto requester = msgBusRequester.request(request, 5);
-      REQUIRE(requester.error() == to_string(DeliveryState::DELIVERY_STATE_UNAVAILABLE));
+        // Test without connection before.
+        auto msgBusRequester = mqtt::MessageBusMqtt("SyncRequesterTestCase", MQTT_SERVER_URI);
+        auto requester       = msgBusRequester.request(request, 5);
+        REQUIRE(requester.error() == DeliveryState::Unavailable);
 
-      // Test with connection after.
-      REQUIRE(msgBusRequester.connect());
-      auto replyMsg = msgBusRequester.request(request, 5);
-      REQUIRE(replyMsg.value().userData() == QUERY_AND_OK);
+        // Test with connection after.
+        REQUIRE(msgBusRequester.connect());
+        auto replyMsg = msgBusRequester.request(request, 5);
+        REQUIRE(replyMsg.value().userData() == QUERY_AND_OK);
     }
 
     SECTION("Send request sync timeout reached")
     {
-      std::string syncTimeOutTestQueue = "/etn/test/message/synctimeout/";
-      auto msgBus = mqtt::MessageBusMqtt("SyncRequesterTimeOutTestCase", MQTT_SERVER_URI);
+        std::string syncTimeOutTestQueue = "/etn/test/message/synctimeout/";
+        auto        msgBus               = mqtt::MessageBusMqtt("SyncRequesterTimeOutTestCase", MQTT_SERVER_URI);
 
-      REQUIRE(msgBus.connect());
+        REQUIRE(msgBus.connect());
 
-      // Send synchronous request
-      Message request = Message::buildRequest("SyncRequesterTimeOutTestCase", syncTimeOutTestQueue + "request", "TEST", syncTimeOutTestQueue + "reply", "test:");
+        // Send synchronous request
+        Message request = Message::
+            buildRequest("SyncRequesterTimeOutTestCase", syncTimeOutTestQueue + "request", "TEST", syncTimeOutTestQueue + "reply", "test:");
 
-      auto replyMsg = msgBus.request(request, 1);
-      REQUIRE(!replyMsg);
-      REQUIRE(from_deliveryState(replyMsg.error()) == DeliveryState::DELIVERY_STATE_TIMEOUT);
+        auto replyMsg = msgBus.request(request, 1);
+        REQUIRE(!replyMsg);
+        REQUIRE(replyMsg.error() == DeliveryState::Timeout);
     }
 
     SECTION("Send async request")
     {
-      std::string asyncTestQueue = "/etn/test/message/async/";
-      auto msgBusRequester = mqtt::MessageBusMqtt("AsyncRequesterTestCase", MQTT_SERVER_URI);
-      REQUIRE(msgBusRequester.connect());
+        std::string asyncTestQueue  = "/etn/test/message/async/";
+        auto        msgBusRequester = mqtt::MessageBusMqtt("AsyncRequesterTestCase", MQTT_SERVER_URI);
+        REQUIRE(msgBusRequester.connect());
 
-      auto msgBusReplyer = mqtt::MessageBusMqtt("AsyncReplyerTestCase", MQTT_SERVER_URI);
-      REQUIRE(msgBusReplyer.connect());
+        auto msgBusReplyer = mqtt::MessageBusMqtt("AsyncReplyerTestCase", MQTT_SERVER_URI);
+        REQUIRE(msgBusReplyer.connect());
 
-      // Build asynchronous request and set all receiver
-      Message request = Message::buildRequest("AsyncRequestTestCase", asyncTestQueue + "request", "TEST", asyncTestQueue + "reply", QUERY);
-      REQUIRE(msgBusReplyer.receive(request.to(), replyerAddOK));
-      REQUIRE(msgBusRequester.receive(request.replyTo(), messageListener, request.correlationId()));
+        // Build asynchronous request and set all receiver
+        Message request =
+            Message::buildRequest("AsyncRequestTestCase", asyncTestQueue + "request", "TEST", asyncTestQueue + "reply", QUERY);
+        REQUIRE(msgBusReplyer.receive(request.to(), replyerAddOK));
+        REQUIRE(msgBusRequester.receive(request.replyTo(), messageListener, request.correlationId()));
 
-      g_msgRecieved.reset();
-      for (int i = 0; i < 2; i++)
-      {
-        REQUIRE(msgBusReplyer.send(request));
+        g_msgRecieved.reset();
+        for (int i = 0; i < 2; i++) {
+            REQUIRE(msgBusReplyer.send(request));
+            std::this_thread::sleep_for(TIMEOUT);
+            REQUIRE((g_msgRecieved.assertValue(i + 1)));
+        }
+    }
+}
+
+TEST_CASE("topic", "[mqtt][pub]")
+{
+    SECTION("Send async request")
+    {
+        auto topic        = "/etn/test/message/pubsub";
+        auto msgBusSender = mqtt::MessageBusMqtt("PubTestCase", MQTT_SERVER_URI);
+        REQUIRE(msgBusSender.connect());
+
+        auto msgBusReceiver = mqtt::MessageBusMqtt("PubTestCaseReceiver", MQTT_SERVER_URI);
+        REQUIRE(msgBusReceiver.connect());
+
+        REQUIRE(msgBusReceiver.receive(topic, messageListener));
+
+        Message msg = Message::buildMessage("PubSubTestCase", topic, "TEST", QUERY);
+        g_msgRecieved.reset();
+        int nbMessageToSend = 3;
+
+        for (int i = 0; i < nbMessageToSend; i++) {
+            REQUIRE(msgBusSender.send(msg));
+        }
         std::this_thread::sleep_for(TIMEOUT);
-        REQUIRE((g_msgRecieved.assertValue(i + 1)));
-      }
-    }
-  }
-
-  TEST_CASE("topic", "[mqtt][pub]")
-  {
-    SECTION("Send async request")
-    {
-      auto topic = "/etn/test/message/pubsub";
-      auto msgBusSender = mqtt::MessageBusMqtt("PubTestCase", MQTT_SERVER_URI);
-      REQUIRE(msgBusSender.connect());
-
-      auto msgBusReceiver = mqtt::MessageBusMqtt("PubTestCaseReceiver", MQTT_SERVER_URI);
-      REQUIRE(msgBusReceiver.connect());
-
-      REQUIRE(msgBusReceiver.receive(topic, messageListener));
-
-      Message msg = Message::buildMessage("PubSubTestCase", topic, "TEST", QUERY);
-      g_msgRecieved.reset();
-      int nbMessageToSend = 3;
-
-      for (int i = 0; i < nbMessageToSend; i++)
-      {
-        REQUIRE(msgBusSender.send(msg) == DeliveryState::DELIVERY_STATE_ACCEPTED);
-      }
-      std::this_thread::sleep_for(TIMEOUT);
-      CHECK(g_msgRecieved.isRecieved(nbMessageToSend));
+        CHECK(g_msgRecieved.isRecieved(nbMessageToSend));
     }
 
     SECTION("Unreceive")
     {
-      auto msgBus = mqtt::MessageBusMqtt("UnreceiveReceiverTestCase", MQTT_SERVER_URI);
-      std::string topic = "/etn/test/message/unreceive";
+        auto        msgBus = mqtt::MessageBusMqtt("UnreceiveReceiverTestCase", MQTT_SERVER_URI);
+        std::string topic  = "/etn/test/message/unreceive";
 
-      // Try to unreceive before a connection => UNAVAILABLE
-      REQUIRE(msgBus.unreceive(topic).error() == to_string(DeliveryState::DELIVERY_STATE_UNAVAILABLE));
-      REQUIRE(msgBus.connect());
-      REQUIRE(msgBus.receive(topic, messageListener));
+        // Try to unreceive before a connection => UNAVAILABLE
+        REQUIRE(msgBus.unreceive(topic).error() == DeliveryState::Unavailable);
+        REQUIRE(msgBus.connect());
+        REQUIRE(msgBus.receive(topic, messageListener));
 
-      auto msgBusSender = mqtt::MessageBusMqtt("UnreceiveSenderTestCase", MQTT_SERVER_URI);
-      REQUIRE(msgBusSender.connect());
+        auto msgBusSender = mqtt::MessageBusMqtt("UnreceiveSenderTestCase", MQTT_SERVER_URI);
+        REQUIRE(msgBusSender.connect());
 
-      Message msg = Message::buildMessage("UnreceiveTestCase", topic, "TEST", QUERY);
-      g_msgRecieved.reset();
-      REQUIRE(msgBusSender.send(msg) == DeliveryState::DELIVERY_STATE_ACCEPTED);
-      std::this_thread::sleep_for(TIMEOUT);
-      CHECK(g_msgRecieved.isRecieved(1));
+        Message msg = Message::buildMessage("UnreceiveTestCase", topic, "TEST", QUERY);
+        g_msgRecieved.reset();
+        REQUIRE(msgBusSender.send(msg));
+        std::this_thread::sleep_for(TIMEOUT);
+        CHECK(g_msgRecieved.isRecieved(1));
 
-      // Try to unreceive a wrong topic => REJECTED
-      REQUIRE(msgBus.unreceive("/etn/t/wrongTopic").error() == to_string(DeliveryState::DELIVERY_STATE_REJECTED));
-      // Try to unreceive a right topic => ACCEPTED
-      REQUIRE(msgBus.unreceive(topic));
-      REQUIRE(msgBusSender.send(msg) == DeliveryState::DELIVERY_STATE_ACCEPTED);
-      std::this_thread::sleep_for(TIMEOUT);
-      CHECK(g_msgRecieved.isRecieved(1));
+        // Try to unreceive a wrong topic => REJECTED
+        REQUIRE(msgBus.unreceive("/etn/t/wrongTopic").error() == DeliveryState::Rejected);
+        // Try to unreceive a right topic => ACCEPTED
+        REQUIRE(msgBus.unreceive(topic));
+        REQUIRE(msgBusSender.send(msg));
+        std::this_thread::sleep_for(TIMEOUT);
+        CHECK(g_msgRecieved.isRecieved(1));
     }
 
     SECTION("Pub sub with same object")
     {
-      auto topic = "/etn/test/message/pubsub";
+        auto topic = "/etn/test/message/pubsub";
 
-      auto msgBus = mqtt::MessageBusMqtt("PubTestCaseWithSameObject", MQTT_SERVER_URI);
-      REQUIRE(msgBus.connect());
+        auto msgBus = mqtt::MessageBusMqtt("PubTestCaseWithSameObject", MQTT_SERVER_URI);
+        REQUIRE(msgBus.connect());
 
-      REQUIRE(msgBus.receive(topic, messageListener));
+        REQUIRE(msgBus.receive(topic, messageListener));
 
-      Message msg = Message::buildMessage("UnreceiveTestCase", topic, "TEST", QUERY);
-      g_msgRecieved.reset();
-      REQUIRE(msgBus.send(msg) == DeliveryState::DELIVERY_STATE_ACCEPTED);
-      std::this_thread::sleep_for(TIMEOUT);
-      CHECK(g_msgRecieved.isRecieved(1));
+        Message msg = Message::buildMessage("UnreceiveTestCase", topic, "TEST", QUERY);
+        g_msgRecieved.reset();
+        REQUIRE(msgBus.send(msg));
+        std::this_thread::sleep_for(TIMEOUT);
+        CHECK(g_msgRecieved.isRecieved(1));
     }
-  }
+}
 
-  TEST_CASE("Wrong", "[mqtt][messageStatus]")
-  {
+TEST_CASE("Wrong", "[mqtt][messageStatus]")
+{
     SECTION("Wrong message")
     {
-      auto msgBus = mqtt::MessageBusMqtt("WrongMessageTestCase", MQTT_SERVER_URI);
+        auto msgBus = mqtt::MessageBusMqtt("WrongMessageTestCase", MQTT_SERVER_URI);
 
-      // Without mandatory fields (from, subject, to)
-      auto wrongSendMsg = Message::buildMessage("WrongMessageTestCase", "", "TEST");
-      REQUIRE(msgBus.send(wrongSendMsg).error() == to_string(DeliveryState::DELIVERY_STATE_REJECTED));
+        // Without mandatory fields (from, subject, to)
+        auto wrongSendMsg = Message::buildMessage("WrongMessageTestCase", "", "TEST");
+        REQUIRE(msgBus.send(wrongSendMsg).error() == DeliveryState::Rejected);
 
-      // Without mandatory fields (from, subject, to)
-      auto request = Message::buildRequest("WrongRequestTestCase", "", "SyncTest", "", QUERY);
-      // Request reject
-      REQUIRE(msgBus.request(request, 1).error() == to_string(DeliveryState::DELIVERY_STATE_REJECTED));
-      request.from("/etn/q/request");
-      request.to("/etn/q/reply");
-      // Without reply request reject.
-      REQUIRE(msgBus.request(request, 1).error() == to_string(DeliveryState::DELIVERY_STATE_REJECTED));
+        // Without mandatory fields (from, subject, to)
+        auto request = Message::buildRequest("WrongRequestTestCase", "", "SyncTest", "", QUERY);
+        // Request reject
+        REQUIRE(msgBus.request(request, 1).error() == DeliveryState::Rejected);
+        request.from("/etn/q/request");
+        request.to("/etn/q/reply");
+        // Without reply request reject.
+        REQUIRE(msgBus.request(request, 1).error() == DeliveryState::Rejected);
     }
 
     SECTION("Wrong connection")
     {
-      auto msgBus = mqtt::MessageBusMqtt("WrongConnectionTestCase", "tcp://wrong.address.ip.com");
-      auto connectionRet = msgBus.connect();
-      REQUIRE(connectionRet.error() == to_string(ComState::COM_STATE_CONNECT_FAILED));
+        auto msgBus        = mqtt::MessageBusMqtt("WrongConnectionTestCase", "tcp://wrong.address.ip.com");
+        auto connectionRet = msgBus.connect();
+        REQUIRE(connectionRet.error() == ComState::ConnectFailed);
     }
-  }
+}
 
 } // namespace

--- a/mqtt/tests/MsgBusMqttTest.cpp
+++ b/mqtt/tests/MsgBusMqttTest.cpp
@@ -18,46 +18,43 @@
 */
 
 #include "src/MsgBusMqtt.h"
+#include <catch2/catch.hpp>
 #include <fty/messagebus/Message.h>
 #include <fty/messagebus/MessageBusStatus.h>
-
-#include <catch2/catch.hpp>
 #include <iostream>
-
 #include <thread>
 
-namespace
-{
+namespace {
+
 #if defined(EXTERNAL_SERVER_FOR_TEST)
-  static constexpr auto MQTT_SERVER_URI{"tcp://mqtt.eclipse.org:1883"};
+static constexpr auto MQTT_SERVER_URI{"tcp://mqtt.eclipse.org:1883"};
 #else
-  static constexpr auto MQTT_SERVER_URI{"tcp://localhost:1883"};
+static constexpr auto MQTT_SERVER_URI{"tcp://localhost:1883"};
 #endif
 
-  using namespace fty::messagebus;
-  using namespace fty::messagebus::mqtt;
+using namespace fty::messagebus;
+using namespace fty::messagebus::mqtt;
 
 } // namespace
 
 TEST_CASE("Mqtt with no connection", "[MsgBusMqtt]")
 {
-  std::string topic = "topic://test.no.connection";
-  Message msg = Message::buildMessage("MqttNoConnectionTestCase", topic, "TEST", "QUERY");
+    std::string topic = "topic://test.no.connection";
+    Message     msg   = Message::buildMessage("MqttNoConnectionTestCase", topic, "TEST", "QUERY");
 
-  auto msgBus = MsgBusMqtt("MqttNoConnectionTestCase", MQTT_SERVER_URI);
-  auto received = msgBus.receive(topic, {});
-  REQUIRE(received.error() == to_string(DeliveryState::DELIVERY_STATE_UNAVAILABLE));
-  auto sent = msgBus.send(msg);
-  REQUIRE(sent.error() == to_string(DeliveryState::DELIVERY_STATE_UNAVAILABLE));
+    auto msgBus   = MsgBusMqtt("MqttNoConnectionTestCase", MQTT_SERVER_URI);
+    auto received = msgBus.receive(topic, {});
+    REQUIRE(received.error() == DeliveryState::Unavailable);
+    auto sent = msgBus.send(msg);
+    REQUIRE(sent.error() == DeliveryState::Unavailable);
 }
 
 TEST_CASE("Mqtt without and with connection", "[MsgBusMqtt]")
 {
-  auto msgBus = MsgBusMqtt("MqttMessageBusStatusTestCase", MQTT_SERVER_URI);
-  CHECK_FALSE(msgBus.isServiceAvailable());
-  auto connectionRet = msgBus.connect();
-  REQUIRE(msgBus.connect());
-  REQUIRE(msgBus.isServiceAvailable());
+    auto msgBus = MsgBusMqtt("MqttMessageBusStatusTestCase", MQTT_SERVER_URI);
+    CHECK_FALSE(msgBus.isServiceAvailable());
+    REQUIRE(msgBus.connect());
+    REQUIRE(msgBus.isServiceAvailable());
 
-  REQUIRE(msgBus.clientName() == "MqttMessageBusStatusTestCase");
+    REQUIRE(msgBus.clientName() == "MqttMessageBusStatusTestCase");
 }

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,7 +1,8 @@
 project(${PROJECT_NAME}-sample
-        VERSION ${PROJECT_VERSION}
-        DESCRIPTION "fty messagebus sample"
-        LANGUAGES CXX)
+    VERSION ${PROJECT_VERSION}
+    DESCRIPTION "fty messagebus sample"
+    LANGUAGES CXX
+)
 
 # Dto(s)
 add_subdirectory(dto)
@@ -12,10 +13,10 @@ add_subdirectory(dto)
 
 # AMQP samples
 if(BUILD_AMQP)
-  add_subdirectory(amqp)
+    add_subdirectory(amqp)
 endif()
 
 # Mqtt samples
 if(BUILD_MQTT)
-  add_subdirectory(mqtt)
+    add_subdirectory(mqtt)
 endif()

--- a/samples/amqp/src/FtyCommonMessagebusAmqpSampleAsyncReply.cpp
+++ b/samples/amqp/src/FtyCommonMessagebusAmqpSampleAsyncReply.cpp
@@ -17,104 +17,91 @@
     =========================================================================
 */
 
-#include <fty/sample/dto/FtyCommonMathDto.h>
-#include <fty/messagebus/amqp/MessageBusAmqp.h>
-
 #include <csignal>
+#include <fty/messagebus/amqp/MessageBusAmqp.h>
+#include <fty/sample/dto/FtyCommonMathDto.h>
 #include <fty_log.h>
 #include <iostream>
 #include <thread>
 
-namespace
+namespace {
+using namespace fty::messagebus;
+using namespace fty::sample::dto;
+
+auto        bus       = amqp::MessageBusAmqp();
+static bool _continue = true;
+
+static void signalHandler(int signal)
 {
-  using namespace fty::messagebus;
-  using namespace fty::sample::dto;
-
-  auto bus = amqp::MessageBusAmqp();
-  static bool _continue = true;
-
-  static void signalHandler(int signal)
-  {
     std::cout << "Signal " << signal << " received\n";
     _continue = false;
-  }
+}
 
-  void replyerMessageListener(const Message& message)
-  {
+void replyerMessageListener(const Message& message)
+{
     logDebug("Message arrived: '{}'", message.toString());
 
-    auto mathQuery = MathOperation(message.userData());
+    auto mathQuery        = MathOperation(message.userData());
     auto mathResultResult = MathResult();
 
-    if (mathQuery.operation == "add")
-    {
-      mathResultResult.result = mathQuery.param_1 + mathQuery.param_2;
-    }
-    else if (mathQuery.operation == "mult")
-    {
-      mathResultResult.result = mathQuery.param_1 * mathQuery.param_2;
-    }
-    else
-    {
-      mathResultResult.status = MathResult::STATUS_KO;
-      mathResultResult.error = "Unsuported operation";
+    if (mathQuery.operation == "add") {
+        mathResultResult.result = mathQuery.param_1 + mathQuery.param_2;
+    } else if (mathQuery.operation == "mult") {
+        mathResultResult.result = mathQuery.param_1 * mathQuery.param_2;
+    } else {
+        mathResultResult.status = MathResult::STATUS_KO;
+        mathResultResult.error  = "Unsuported operation";
     }
 
     fty::Expected<Message> response = message.buildReply(mathResultResult.serialize());
-    if (!response)
-    {
-      logError("Error while creating reply: {}", response.error());
-      return;
+    if (!response) {
+        logError("Error while creating reply: {}", response.error());
+        return;
     }
 
-    fty::Expected<void> sendRet = bus.send(response.value());
-    if (!sendRet)
-    {
-      logError("Error while sending: {}", sendRet.error());
-      return;
+    auto sendRet = bus.send(response.value());
+    if (!sendRet) {
+        logError("Error while sending: {}", to_string(sendRet.error()));
+        return;
     }
 
     //_continue = false;
-  }
+}
 
 } // namespace
 
 int main(int argc, char** argv)
 {
-  if (argc != 2)
-  {
-    std::cout << "USAGE: " << argv[0] << " <repQueue>" << std::endl;
-    return EXIT_FAILURE;
-  }
+    if (argc != 2) {
+        std::cout << "USAGE: " << argv[0] << " <repQueue>" << std::endl;
+        return EXIT_FAILURE;
+    }
 
-  logInfo("{} - starting...", argv[0]);
+    logInfo("{} - starting...", argv[0]);
 
-  auto address = std::string{argv[1]};
+    auto address = std::string{argv[1]};
 
-  // Install a signal handler
-  std::signal(SIGINT, signalHandler);
-  std::signal(SIGTERM, signalHandler);
+    // Install a signal handler
+    std::signal(SIGINT, signalHandler);
+    std::signal(SIGTERM, signalHandler);
 
-  fty::Expected<void> connectionRet = bus.connect();
-  if (!connectionRet)
-  {
-    logError("Error while connecting {}", connectionRet.error());
-    return EXIT_FAILURE;
-  }
+    auto connectionRet = bus.connect();
+    if (!connectionRet) {
+        logError("Error while connecting {}", to_string(connectionRet.error()));
+        return EXIT_FAILURE;
+    }
 
-  fty::Expected<void> subscribRet = bus.receive(address, replyerMessageListener);
-  if (!subscribRet)
-  {
-    logError("Error while subscribing {}", subscribRet.error());
-    return EXIT_FAILURE;
-  }
+    auto subscribRet = bus.receive(address, replyerMessageListener);
+    if (!subscribRet) {
+        logError("Error while subscribing {}", to_string(subscribRet.error()));
+        return EXIT_FAILURE;
+    }
 
 
-  while (_continue)
-  {
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  }
+    while (_continue) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
 
-  logInfo("{} - end", argv[0]);
-  return EXIT_SUCCESS;
+    logInfo("{} - end", argv[0]);
+    return EXIT_SUCCESS;
 }

--- a/samples/amqp/src/FtyCommonMessagebusAmqpSamplePubSub.cpp
+++ b/samples/amqp/src/FtyCommonMessagebusAmqpSamplePubSub.cpp
@@ -17,36 +17,34 @@
     =========================================================================
 */
 
+#include <csignal>
 #include <fty/messagebus/amqp/MessageBusAmqp.h>
 #include <fty/sample/dto/FtyCommonFooBarDto.h>
-
-#include <csignal>
 #include <fty_log.h>
-#include <iostream>
 #include <future>
+#include <iostream>
 
-namespace
+namespace {
+
+using namespace fty::messagebus;
+using namespace fty::sample::dto;
+
+static auto constexpr SAMPLE_TOPIC = "topic://etn.t.samples.pubsub";
+// ensure that we received the message
+static std::promise<bool> g_received;
+
+static void signalHandler(int signal)
 {
-  using namespace fty::messagebus;
-  using namespace fty::sample::dto;
-
-  static auto constexpr SAMPLE_TOPIC = "topic://etn.t.samples.pubsub";
-  // ensure that we received the message
-  static std::promise<bool> g_received;
-
-  static void signalHandler(int signal)
-  {
     std::cout << "Signal " << signal << " received\n";
     g_received.set_value(false);
-  }
+}
 
-  void messageListener(const Message& message)
-  {
+void messageListener(const Message& message)
+{
     logInfo("messageListener");
     auto metadata = message.metaData();
-    for (const auto& pair : message.metaData())
-    {
-      logInfo("  ** '{}' : '{}'", pair.first, pair.second);
+    for (const auto& pair : message.metaData()) {
+        logInfo("  ** '{}' : '{}'", pair.first, pair.second);
     }
 
     auto fooBar = FooBar(message.userData());
@@ -54,46 +52,43 @@ namespace
     logInfo("  * bar    : '{}'", fooBar.bar);
 
     g_received.set_value(true);
-  }
+}
 
 } // namespace
 
 int main(int /*argc*/, char** argv)
 {
-  logInfo("{} - starting...", argv[0]);
+    logInfo("{} - starting...", argv[0]);
 
-  // Install a signal handler
-  std::signal(SIGINT, signalHandler);
-  std::signal(SIGTERM, signalHandler);
+    // Install a signal handler
+    std::signal(SIGINT, signalHandler);
+    std::signal(SIGTERM, signalHandler);
 
-  auto bus = amqp::MessageBusAmqp();
+    auto bus = amqp::MessageBusAmqp();
 
-  fty::Expected<void> connectionRet = bus.connect();
-  if (!connectionRet)
-  {
-    logError("Error while connecting {}", connectionRet.error());
-    return EXIT_FAILURE;
-  }
+    auto connectionRet = bus.connect();
+    if (!connectionRet) {
+        logError("Error while connecting {}", to_string(connectionRet.error()));
+        return EXIT_FAILURE;
+    }
 
-  fty::Expected<void> subscribRet = bus.receive(SAMPLE_TOPIC, messageListener);
-  if (!subscribRet)
-  {
-    logError("Error while subscribing {}", subscribRet.error());
-    return EXIT_FAILURE;
-  }
+    auto subscribRet = bus.receive(SAMPLE_TOPIC, messageListener);
+    if (!subscribRet) {
+        logError("Error while subscribing {}", to_string(subscribRet.error()));
+        return EXIT_FAILURE;
+    }
 
-  // Build message
-  Message msg = Message::buildMessage(argv[0], SAMPLE_TOPIC, "PublishMessage", FooBar("event", "hello").serialize());
+    // Build message
+    Message msg = Message::buildMessage(argv[0], SAMPLE_TOPIC, "PublishMessage", FooBar("event", "hello").serialize());
 
-  // Send message
-  fty::Expected<void> sendRet = bus.send(msg);
-  if (!sendRet)
-  {
-    logError("Error while sending {}", sendRet.error());
-    return EXIT_FAILURE;
-  }
+    // Send message
+    auto sendRet = bus.send(msg);
+    if (!sendRet) {
+        logError("Error while sending {}", to_string(sendRet.error()));
+        return EXIT_FAILURE;
+    }
 
-  g_received.get_future().get();
-  logInfo("{} - end", argv[0]);
-  return EXIT_SUCCESS;
+    g_received.get_future().get();
+    logInfo("{} - end", argv[0]);
+    return EXIT_SUCCESS;
 }

--- a/samples/amqp/src/FtyCommonMessagebusAmqpSampleSendRequest.cpp
+++ b/samples/amqp/src/FtyCommonMessagebusAmqpSampleSendRequest.cpp
@@ -17,120 +17,108 @@
     =========================================================================
 */
 
-#include <fty/sample/dto/FtyCommonMathDto.h>
-#include <fty/messagebus/amqp/MessageBusAmqp.h>
-
 #include <csignal>
+#include <fty/messagebus/amqp/MessageBusAmqp.h>
+#include <fty/sample/dto/FtyCommonMathDto.h>
 #include <fty_log.h>
 #include <iostream>
 #include <thread>
 
-namespace
+namespace {
+
+using namespace fty::messagebus;
+using namespace fty::sample::dto;
+
+static bool _continue                      = true;
+static auto constexpr SYNC_REQUEST_TIMEOUT = 5;
+
+static void signalHandler(int signal)
 {
-  using namespace fty::messagebus;
-  using namespace fty::sample::dto;
-
-  static bool _continue = true;
-  static auto constexpr SYNC_REQUEST_TIMEOUT = 5;
-
-  static void signalHandler(int signal)
-  {
     std::cout << "Signal " << signal << " received\n";
     _continue = false;
-  }
+}
 
-  void responseMessageListener(const Message& message)
-  {
+void responseMessageListener(const Message& message)
+{
     logInfo("Response arrived: {}", message.toString());
     auto mathresult = MathResult(message.userData());
     logInfo("  * status: '{}', result: {}, error: '{}'", mathresult.status, mathresult.result, mathresult.error);
 
     _continue = false;
-  }
+}
 
 } // namespace
 
 int main(int argc, char** argv)
 {
-  if (argc != 6)
-  {
-    std::cout << "USAGE: " << argv[0] << " <reqQueue, i.e. queue://etn.q.samples.maths/> <async|sync> <add|mult> <num1> <num2>" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  logInfo("{} - starting...", argv[0]);
-
-  auto requestQueue = std::string{argv[1]};
-  auto replyQueue = requestQueue + ".reply";
-
-  // Install a signal handler
-  std::signal(SIGINT, signalHandler);
-  std::signal(SIGTERM, signalHandler);
-
-  auto bus = amqp::MessageBusAmqp(argv[0]);
-
-  // Bus connection
-  fty::Expected<void> connectionRet = bus.connect();
-  if (!connectionRet)
-  {
-    logError("Error while connecting {}", connectionRet.error());
-    return EXIT_FAILURE;
-  }
-
-  auto operationQuery = MathOperation(argv[3], std::stoi(argv[4]), std::stoi(argv[5]));
-
-  Message request = Message::buildRequest("MathsOperationsRequester", requestQueue, "MathsOperations", replyQueue, operationQuery.serialize());
-
-  if (strcmp(argv[2], "sync") == 0)
-  {
-    _continue = false;
-
-    fty::Expected<Message> reply = bus.request(request, SYNC_REQUEST_TIMEOUT);
-    if (!reply)
-    {
-      std::cerr << "Error while requesting " << reply.error() << std::endl;
-      return EXIT_FAILURE;
-    }
-
-    if (reply.value().status() != STATUS_OK)
-    {
-      std::cerr << "An error occured, message status is not OK!" << std::endl;
-      return EXIT_FAILURE;
-    }
-
-    responseMessageListener(reply.value());
-  }
-  else
-  {
-    if (strcmp(argv[2], "async") == 0)
-    {
-
-      fty::Expected<void> subscribRet = bus.receive(replyQueue, responseMessageListener, request.correlationId());
-      if (!subscribRet)
-      {
-        logError("Error while subscribing {}", subscribRet.error());
+    if (argc != 6) {
+        std::cout << "USAGE: " << argv[0] << " <reqQueue, i.e. queue://etn.q.samples.maths/> <async|sync> <add|mult> <num1> <num2>"
+                  << std::endl;
         return EXIT_FAILURE;
-      }
-    }
-    else
-    {
-      // Simple send message
-      _continue = false;
     }
 
-    fty::Expected<void> sendRet = bus.send(request);
-    if (!sendRet)
-    {
-      logError("Error while sending: {}", sendRet.error());
-      return EXIT_FAILURE;
+    logInfo("{} - starting...", argv[0]);
+
+    auto requestQueue = std::string{argv[1]};
+    auto replyQueue   = requestQueue + ".reply";
+
+    // Install a signal handler
+    std::signal(SIGINT, signalHandler);
+    std::signal(SIGTERM, signalHandler);
+
+    auto bus = amqp::MessageBusAmqp(argv[0]);
+
+    // Bus connection
+    auto connectionRet = bus.connect();
+    if (!connectionRet) {
+        logError("Error while connecting {}", to_string(connectionRet.error()));
+        return EXIT_FAILURE;
     }
-  }
 
-  while (_continue)
-  {
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  }
+    auto operationQuery = MathOperation(argv[3], std::stoi(argv[4]), std::stoi(argv[5]));
 
-  logInfo("{} - end", argv[0]);
-  return EXIT_SUCCESS;
+    Message request =
+        Message::buildRequest("MathsOperationsRequester", requestQueue, "MathsOperations", replyQueue, operationQuery.serialize());
+
+    if (strcmp(argv[2], "sync") == 0) {
+        _continue = false;
+
+        auto reply = bus.request(request, SYNC_REQUEST_TIMEOUT);
+        if (!reply) {
+            std::cerr << "Error while requesting " << to_string(reply.error()) << std::endl;
+            return EXIT_FAILURE;
+        }
+
+        if (reply.value().status() != STATUS_OK) {
+            std::cerr << "An error occured, message status is not OK!" << std::endl;
+            return EXIT_FAILURE;
+        }
+
+        responseMessageListener(reply.value());
+    } else {
+        if (strcmp(argv[2], "async") == 0) {
+
+            auto subscribRet = bus.receive(replyQueue, responseMessageListener, request.correlationId());
+            if (!subscribRet) {
+                logError("Error while subscribing {}", to_string(subscribRet.error()));
+                return EXIT_FAILURE;
+            }
+        } else {
+            // Simple send message
+            _continue = false;
+        }
+
+        auto sendRet = bus.send(request);
+        if (!sendRet) {
+            logError("Error while sending: {}", to_string(sendRet.error()));
+            return EXIT_FAILURE;
+        }
+    }
+
+    while (_continue) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    logInfo("{} - end", argv[0]);
+    return EXIT_SUCCESS;
 }

--- a/samples/mqtt/daemon/client.cpp
+++ b/samples/mqtt/daemon/client.cpp
@@ -17,48 +17,48 @@
     =========================================================================
 */
 
-#include <fty/messagebus/mqtt/MessageBusMqtt.h>
 #include <fty/messagebus/Message.h>
-
+#include <fty/messagebus/mqtt/MessageBusMqtt.h>
 #include <iostream>
 
 using namespace fty::messagebus;
 
 int main(int argc, char** argv)
 {
-  //Check the argument
-  if(argc != 2) {
-    std::cerr << argv[0] << " usage:" << std::endl;
-    std::cerr << "\t" << argv[0] << " <string to change>" << std::endl;
-    return EXIT_FAILURE;
-  }
+    // Check the argument
+    if (argc != 2) {
+        std::cerr << argv[0] << " usage:" << std::endl;
+        std::cerr << "\t" << argv[0] << " <string to change>" << std::endl;
+        return EXIT_FAILURE;
+    }
 
-  auto bus = mqtt::MessageBusMqtt();
+    auto bus = mqtt::MessageBusMqtt();
 
-  //Connect to the bus
-  fty::Expected<void> connectionRet = bus.connect();
-  if(! connectionRet ) {
-    std::cerr <<  "Error while connecting " << connectionRet.error() << std::endl;
-    return EXIT_FAILURE;
-  }
+    // Connect to the bus
+    auto connectionRet = bus.connect();
+    if (!connectionRet) {
+        std::cerr << "Error while connecting " << to_string(connectionRet.error()) << std::endl;
+        return EXIT_FAILURE;
+    }
 
-  //Build the request --> TODO: We need a way to auto generate the reply queue
-  Message request = Message::buildRequest(argv[0], "/etn/samples/daemon-basic/mailbox", "TO_UPPER", "/etn/samples/daemon-basic/reply/" + utils::generateId(), argv[1]);
+    // Build the request --> TODO: We need a way to auto generate the reply queue
+    Message request = Message::buildRequest(
+        argv[0], "/etn/samples/daemon-basic/mailbox", "TO_UPPER", "/etn/samples/daemon-basic/reply/" + utils::generateId(), argv[1]);
 
-  //Subscrib to the bus
-  fty::Expected<Message> reply = bus.request(request, 1);
-  if(! reply ) {
-    std::cerr << "Error while requesting " << reply.error() << std::endl;
-    return EXIT_FAILURE;
-  }
+    // Subscrib to the bus
+    auto reply = bus.request(request, 1);
+    if (!reply) {
+        std::cerr << "Error while requesting " << to_string(reply.error()) << std::endl;
+        return EXIT_FAILURE;
+    }
 
-  if( reply.value().status() != STATUS_OK ) {
-    std::cerr << "An error occured, message status is not OK!" << std::endl;
-    return EXIT_FAILURE;
-  }
+    if (reply.value().status() != STATUS_OK) {
+        std::cerr << "An error occured, message status is not OK!" << std::endl;
+        return EXIT_FAILURE;
+    }
 
-  // We print the result
-  std::cout << reply.value().userData() << std::endl;
+    // We print the result
+    std::cout << reply.value().userData() << std::endl;
 
-  return EXIT_SUCCESS;
+    return EXIT_SUCCESS;
 }

--- a/samples/mqtt/publish/publish.cpp
+++ b/samples/mqtt/publish/publish.cpp
@@ -17,13 +17,11 @@
     =========================================================================
 */
 
-#include <fty/messagebus/mqtt/MessageBusMqtt.h>
-
 #include <csignal>
-#include <iostream>
-#include <future>
-
+#include <fty/messagebus/mqtt/MessageBusMqtt.h>
 #include <fty_log.h>
+#include <future>
+#include <iostream>
 
 using namespace fty::messagebus;
 
@@ -35,43 +33,43 @@ void messageListener(Message message);
 
 int main(int /*argc*/, char** argv)
 {
-  logInfo("{} - starting...", argv[0]);
+    logInfo("{} - starting...", argv[0]);
 
-  //Create the bus object
-  auto bus = mqtt::MessageBusMqtt(argv[0]);
+    // Create the bus object
+    auto bus = mqtt::MessageBusMqtt(argv[0]);
 
-  //Connect to the bus
-  fty::Expected<void> connectionRet = bus.connect();
-  if(! connectionRet) {
-    logError("Error while connecting {}", connectionRet.error());
-    return EXIT_FAILURE;
-  }
+    // Connect to the bus
+    auto connectionRet = bus.connect();
+    if (!connectionRet) {
+        logError("Error while connecting {}", to_string(connectionRet.error()));
+        return EXIT_FAILURE;
+    }
 
-  //Subscrib to the bus
-  fty::Expected<void> subscribRet = bus.receive("/etn/samples/publish", messageListener);
-  if(! subscribRet) {
-    logError("Error while subscribing {}", subscribRet.error());
-    return EXIT_FAILURE;
-  }
+    // Subscrib to the bus
+    auto subscribRet = bus.receive("/etn/samples/publish", messageListener);
+    if (!subscribRet) {
+        logError("Error while subscribing {}", to_string(subscribRet.error()));
+        return EXIT_FAILURE;
+    }
 
-  //Build the message to send
-  Message msg = Message::buildMessage(argv[0], "/etn/samples/publish", "MESSAGE", "This is my test message");
+    // Build the message to send
+    Message msg = Message::buildMessage(argv[0], "/etn/samples/publish", "MESSAGE", "This is my test message");
 
-  //Send the message
-  fty::Expected<void> sendRet = bus.send(msg);
-  if(!sendRet ) {
-    logError("Error while sending {}", sendRet.error());
-    return EXIT_FAILURE;
-  }
+    // Send the message
+    auto sendRet = bus.send(msg);
+    if (!sendRet) {
+        logError("Error while sending {}", to_string(sendRet.error()));
+        return EXIT_FAILURE;
+    }
 
-  //Wait until the second thread receive the message
-  g_received.get_future().get();
-  logInfo("{} - end", argv[0]);
-  return EXIT_SUCCESS;
+    // Wait until the second thread receive the message
+    g_received.get_future().get();
+    logInfo("{} - end", argv[0]);
+    return EXIT_SUCCESS;
 }
 
 void messageListener(Message message)
 {
-  logInfo("messageListener recieved: \n{}", message.toString().c_str());
-  g_received.set_value(true);
+    logInfo("messageListener recieved: \n{}", message.toString().c_str());
+    g_received.set_value(true);
 }

--- a/samples/mqtt/src/FtyCommonMessagebusMqttSampleAsyncReply.cpp
+++ b/samples/mqtt/src/FtyCommonMessagebusMqttSampleAsyncReply.cpp
@@ -20,102 +20,89 @@
 */
 
 #include "fty/sample/dto/FtyCommonMathDto.h"
+#include <csignal>
 #include <fty/messagebus/MessageBus.h>
 #include <fty/messagebus/MessageBusStatus.h>
 #include <fty/messagebus/mqtt/MessageBusMqtt.h>
-
-#include <csignal>
 #include <fty_log.h>
 #include <iostream>
 #include <thread>
 
-namespace
+namespace {
+using namespace fty::messagebus;
+using namespace fty::sample::dto;
+static auto constexpr MATHS_OPERATOR_QUEUE = "/etn/q/request/maths/operator";
+
+static bool _continue = true;
+
+auto msgBus = mqtt::MessageBusMqtt();
+
+static void signalHandler(int signal)
 {
-  using namespace fty::messagebus;
-  using namespace fty::sample::dto;
-  static auto constexpr MATHS_OPERATOR_QUEUE = "/etn/q/request/maths/operator";
-
-  static bool _continue = true;
-
-  auto msgBus = mqtt::MessageBusMqtt();
-
-  static void signalHandler(int signal)
-  {
     std::cout << "Signal " << signal << " received\n";
     _continue = false;
-  }
+}
 
-  void replyerMessageListener(const Message& message)
-  {
+void replyerMessageListener(const Message& message)
+{
     logInfo("Replyer messageListener");
 
-    for (const auto& pair : message.metaData())
-    {
-      logInfo("  ** '{}' : '{}'", pair.first.c_str(), pair.second.c_str());
+    for (const auto& pair : message.metaData()) {
+        logInfo("  ** '{}' : '{}'", pair.first.c_str(), pair.second.c_str());
     }
 
-    auto mathQuery = MathOperation(message.userData());
+    auto mathQuery        = MathOperation(message.userData());
     auto mathResultResult = MathResult();
 
-    if (mathQuery.operation == "add")
-    {
-      mathResultResult.result = mathQuery.param_1 + mathQuery.param_2;
-    }
-    else if (mathQuery.operation == "mult")
-    {
-      mathResultResult.result = mathQuery.param_1 * mathQuery.param_2;
-    }
-    else
-    {
-      mathResultResult.status = MathResult::STATUS_KO;
-      mathResultResult.error = "Unsuported operation";
+    if (mathQuery.operation == "add") {
+        mathResultResult.result = mathQuery.param_1 + mathQuery.param_2;
+    } else if (mathQuery.operation == "mult") {
+        mathResultResult.result = mathQuery.param_1 * mathQuery.param_2;
+    } else {
+        mathResultResult.status = MathResult::STATUS_KO;
+        mathResultResult.error  = "Unsuported operation";
     }
 
-    //Build the response
+    // Build the response
     auto response = message.buildReply(mathResultResult.serialize());
-    if (!response)
-    {
-      logError("Error on buildReply {}", response.error());
+    if (!response) {
+        logError("Error on buildReply {}", response.error());
     }
-    //send the response
+    // send the response
     auto returnSend = msgBus.send(response.value());
-    if (!returnSend)
-    {
-      logError("Error on send {}", returnSend.error());
+    if (!returnSend) {
+        logError("Error on send {}", to_string(returnSend.error()));
     }
     //_continue = false;
-  }
+}
 
 } // namespace
 
 int main(int /*argc*/, char** argv)
 {
-  logInfo("{} - starting...", argv[0]);
+    logInfo("{} - starting...", argv[0]);
 
-  // Install a signal handler
-  std::signal(SIGINT, signalHandler);
-  std::signal(SIGTERM, signalHandler);
+    // Install a signal handler
+    std::signal(SIGINT, signalHandler);
+    std::signal(SIGTERM, signalHandler);
 
-  //Connect to the bus
-  fty::Expected<void> connectionRet = msgBus.connect();
-  if (!connectionRet)
-  {
-    logError("Error while connecting {}", connectionRet.error());
-    return EXIT_FAILURE;
-  }
+    // Connect to the bus
+    auto connectionRet = msgBus.connect();
+    if (!connectionRet) {
+        logError("Error while connecting {}", to_string(connectionRet.error()));
+        return EXIT_FAILURE;
+    }
 
-  fty::Expected<void> subscribRet = msgBus.receive(MATHS_OPERATOR_QUEUE, replyerMessageListener);
-  if (!subscribRet)
-  {
-    logError("Error while subscribing {}", subscribRet.error());
-    return EXIT_FAILURE;
-  }
+    auto subscribRet = msgBus.receive(MATHS_OPERATOR_QUEUE, replyerMessageListener);
+    if (!subscribRet) {
+        logError("Error while subscribing {}", to_string(subscribRet.error()));
+        return EXIT_FAILURE;
+    }
 
-  while (_continue)
-  {
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  }
+    while (_continue) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
 
-  logInfo("{} - end", argv[0]);
-  return EXIT_SUCCESS;
+    logInfo("{} - end", argv[0]);
+    return EXIT_SUCCESS;
 }

--- a/samples/mqtt/src/FtyCommonMessagebusMqttSampleDiscovery.cpp
+++ b/samples/mqtt/src/FtyCommonMessagebusMqttSampleDiscovery.cpp
@@ -19,48 +19,46 @@
     =========================================================================
 */
 
-#include <fty/messagebus/mqtt/MessageBusMqtt.h>
-
 #include <csignal>
+#include <fty/messagebus/mqtt/MessageBusMqtt.h>
 #include <fty_log.h>
 #include <iostream>
 #include <thread>
 
-namespace
+namespace {
+
+using namespace fty::messagebus;
+
+static bool _continue = true;
+
+static void signalHandler(int signal)
 {
-  using namespace fty::messagebus;
-
-  static bool _continue = true;
-
-  static void signalHandler(int signal)
-  {
     std::cout << "Signal " << signal << " received\n";
     _continue = false;
-  }
+}
+
 } // namespace
 
 int main(int /*argc*/, char** argv)
 {
-  logInfo("{} - starting...", argv[0]);
+    logInfo("{} - starting...", argv[0]);
 
-  // Install a signal handler
-  std::signal(SIGINT, signalHandler);
-  std::signal(SIGTERM, signalHandler);
+    // Install a signal handler
+    std::signal(SIGINT, signalHandler);
+    std::signal(SIGTERM, signalHandler);
 
-  auto msgBus = mqtt::MessageBusMqtt();
-  //Connect to the bus
-  fty::Expected<void> connectionRet = msgBus.connect();
-  if (!connectionRet)
-  {
-    logError("Error while connecting {}", connectionRet.error());
-    return EXIT_FAILURE;
-  }
+    auto msgBus = mqtt::MessageBusMqtt();
+    // Connect to the bus
+    auto connectionRet = msgBus.connect();
+    if (!connectionRet) {
+        logError("Error while connecting {}", to_string(connectionRet.error()));
+        return EXIT_FAILURE;
+    }
 
-  while (_continue)
-  {
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  }
+    while (_continue) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
 
-  logInfo("{} - end", argv[0]);
-  return EXIT_SUCCESS;
+    logInfo("{} - end", argv[0]);
+    return EXIT_SUCCESS;
 }

--- a/samples/mqtt/src/FtyCommonMessagebusMqttSampleSendRequest.cpp
+++ b/samples/mqtt/src/FtyCommonMessagebusMqttSampleSendRequest.cpp
@@ -20,105 +20,92 @@
 */
 
 #include "fty/sample/dto/FtyCommonMathDto.h"
+#include <csignal>
 #include <fty/messagebus/MessageBus.h>
 #include <fty/messagebus/MessageBusStatus.h>
 #include <fty/messagebus/mqtt/MessageBusMqtt.h>
-
-#include <csignal>
 #include <fty_log.h>
 #include <iostream>
 #include <thread>
 
-namespace
+namespace {
+using namespace fty::messagebus;
+using namespace fty::sample::dto;
+
+static bool _continue                            = true;
+static auto constexpr SYNC_REQUEST_TIMEOUT       = 5;
+static auto constexpr MATHS_OPERATOR_REPLY_QUEUE = "/etn/q/reply/maths/operator";
+
+static void signalHandler(int signal)
 {
-  using namespace fty::messagebus;
-  using namespace fty::sample::dto;
-
-  static bool _continue = true;
-  static auto constexpr SYNC_REQUEST_TIMEOUT = 5;
-  static auto constexpr MATHS_OPERATOR_REPLY_QUEUE = "/etn/q/reply/maths/operator";
-
-  static void signalHandler(int signal)
-  {
     std::cout << "Signal " << signal << " received\n";
     _continue = false;
-  }
+}
 
-  void responseMessageListener(const Message& message)
-  {
+void responseMessageListener(const Message& message)
+{
     logInfo("Response arrived");
     auto mathresult = MathResult(message.userData());
     logInfo("  * status: '{}', result: %d, error: '{}'", mathresult.status.c_str(), mathresult.result, mathresult.error.c_str());
 
     _continue = false;
-  }
+}
 
 } // namespace
 
 int main(int argc, char** argv)
 {
-  if (argc != 6)
-  {
-    std::cout << "USAGE: " << argv[0] << " <reqQueue> <async|sync> <add|mult> <num1> <num2>" << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  logInfo("{} - starting...", argv[0]);
-
-  auto requestQueue = std::string{argv[1]};
-
-  // Install a signal handler
-  std::signal(SIGINT, signalHandler);
-  std::signal(SIGTERM, signalHandler);
-
-  auto msgBus = mqtt::MessageBusMqtt();
-  //Connect to the bus
-  fty::Expected<void> connectionRet = msgBus.connect();
-  if (!connectionRet)
-  {
-    logError("Error while connecting {}", connectionRet.error());
-    return EXIT_FAILURE;
-  }
-
-  auto query = MathOperation(argv[3], std::stoi(argv[4]), std::stoi(argv[5]));
-  //Build the message to send
-  Message msg = Message::buildRequest(argv[0], requestQueue, "mathQuery", MATHS_OPERATOR_REPLY_QUEUE, query.serialize());
-
-  if (strcmp(argv[2], "async") == 0)
-  {
-    fty::Expected<void> subscribRet = msgBus.receive(msg.replyTo(), responseMessageListener);
-    if (!subscribRet)
-    {
-      logError("Error while subscribing {}", subscribRet.error());
-      return EXIT_FAILURE;
+    if (argc != 6) {
+        std::cout << "USAGE: " << argv[0] << " <reqQueue> <async|sync> <add|mult> <num1> <num2>" << std::endl;
+        return EXIT_FAILURE;
     }
-    fty::Expected<void> sendRet = msgBus.send(msg);
-    if (!sendRet)
-    {
-      logError("Error while sending {}", sendRet.error());
-      return EXIT_FAILURE;
-    }
-  }
-  else
-  {
-    _continue = false;
 
-    auto replyMsg = msgBus.request(msg, SYNC_REQUEST_TIMEOUT);
-    if (replyMsg)
-    {
-      responseMessageListener(replyMsg.value());
-    }
-    else
-    {
-      logError("Time out reached: (%ds)", SYNC_REQUEST_TIMEOUT);
-    }
-  }
+    logInfo("{} - starting...", argv[0]);
 
-  while (_continue)
-  {
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  }
+    auto requestQueue = std::string{argv[1]};
 
-  logInfo("{} - end", argv[0]);
-  return EXIT_SUCCESS;
+    // Install a signal handler
+    std::signal(SIGINT, signalHandler);
+    std::signal(SIGTERM, signalHandler);
+
+    auto msgBus = mqtt::MessageBusMqtt();
+    // Connect to the bus
+    auto connectionRet = msgBus.connect();
+    if (!connectionRet) {
+        logError("Error while connecting {}", to_string(connectionRet.error()));
+        return EXIT_FAILURE;
+    }
+
+    auto query = MathOperation(argv[3], std::stoi(argv[4]), std::stoi(argv[5]));
+    // Build the message to send
+    Message msg = Message::buildRequest(argv[0], requestQueue, "mathQuery", MATHS_OPERATOR_REPLY_QUEUE, query.serialize());
+
+    if (strcmp(argv[2], "async") == 0) {
+        auto subscribRet = msgBus.receive(msg.replyTo(), responseMessageListener);
+        if (!subscribRet) {
+            logError("Error while subscribing {}", to_string(subscribRet.error()));
+            return EXIT_FAILURE;
+        }
+        auto sendRet = msgBus.send(msg);
+        if (!sendRet) {
+            logError("Error while sending {}", to_string(sendRet.error()));
+            return EXIT_FAILURE;
+        }
+    } else {
+        _continue = false;
+
+        auto replyMsg = msgBus.request(msg, SYNC_REQUEST_TIMEOUT);
+        if (replyMsg) {
+            responseMessageListener(replyMsg.value());
+        } else {
+            logError("Time out reached: (%ds)", SYNC_REQUEST_TIMEOUT);
+        }
+    }
+
+    while (_continue) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    logInfo("{} - end", argv[0]);
+    return EXIT_SUCCESS;
 }

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,23 +1,21 @@
 project(fty-common-messagebus-utils
-        VERSION ${PROJECT_VERSION}
-        DESCRIPTION "fty messagebus utilitary static library"
+    VERSION ${PROJECT_VERSION}
+    DESCRIPTION "fty messagebus utilitary static library"
 )
 
 etn_target(static ${PROJECT_NAME} PRIVATE
-  PUBLIC_INCLUDE_DIR
-    public_include
-  PUBLIC_HEADERS
-    *.hpp
-  SOURCES
-    src/*.cpp
-  USES_PUBLIC
-    pthread
+    PUBLIC_INCLUDE_DIR
+        public_include
+    PUBLIC_HEADERS
+        *.hpp
+    SOURCES
+        src/*.cpp
+    USES_PUBLIC
+        pthread
 )
 
 ## Tests
-if(BUILD_TESTING)
-  etn_test_target(${PROJECT_NAME}
+etn_test_target(${PROJECT_NAME}
     SOURCES
-      tests/*.cpp
-  )
-endif()
+        tests/*.cpp
+)

--- a/utils/public_include/fty/messagebus/utils/MsgBusDispatcher.hpp
+++ b/utils/public_include/fty/messagebus/utils/MsgBusDispatcher.hpp
@@ -22,16 +22,15 @@
 #include <functional>
 #include <map>
 
-namespace fty::messagebus::utils
-{
+namespace fty::messagebus::utils {
 
-  /**
-  * @brief Callable dispatcher based on std::map.
-  */
-  template <class KeyType, typename WorkFunctionType, typename MissingFunctionType>
-  class Dispatcher
-  {
-  public:
+/**
+ * @brief Callable dispatcher based on std::map.
+ */
+template <class KeyType, typename WorkFunctionType, typename MissingFunctionType>
+class Dispatcher
+{
+public:
     /// @brief Map of (key -> callable).
     using Map = std::map<KeyType, WorkFunctionType>;
 
@@ -40,7 +39,7 @@ namespace fty::messagebus::utils
      * \param map Function map.
      */
     Dispatcher(const Map& map)
-      : Dispatcher(map, MissingFunctionType())
+        : Dispatcher(map, MissingFunctionType())
     {
     }
 
@@ -50,8 +49,8 @@ namespace fty::messagebus::utils
      * \param defaultHandler Default handler callable.
      */
     Dispatcher(const Map& map, MissingFunctionType defaultHandler)
-      : m_map(map)
-      , m_defaultHandler(defaultHandler)
+        : m_map(map)
+        , m_defaultHandler(defaultHandler)
     {
     }
 
@@ -65,17 +64,16 @@ namespace fty::messagebus::utils
     template <typename... ArgsType>
     typename WorkFunctionType::result_type operator()(const KeyType& key, ArgsType&&... args)
     {
-      auto it = m_map.find(key);
-      if (it != m_map.end())
-      {
-        return it->second(std::forward<ArgsType>(args)...);
-      }
-      return m_defaultHandler(key, std::forward<ArgsType>(args)...);
+        auto it = m_map.find(key);
+        if (it != m_map.end()) {
+            return it->second(std::forward<ArgsType>(args)...);
+        }
+        return m_defaultHandler(key, std::forward<ArgsType>(args)...);
     }
 
-  private:
-    Map m_map;
+private:
+    Map                 m_map;
     MissingFunctionType m_defaultHandler;
-  };
+};
 
 } // namespace fty::messagebus::utils

--- a/utils/src/MsgBusPoolWorker.cpp
+++ b/utils/src/MsgBusPoolWorker.cpp
@@ -19,79 +19,70 @@
 
 #include "fty/messagebus/utils/MsgBusPoolWorker.hpp"
 
-namespace fty::messagebus::utils
-{
-  PoolWorker::PoolWorker(size_t workers)
+namespace fty::messagebus::utils {
+PoolWorker::PoolWorker(size_t workers)
     : m_terminated(false)
-  {
+{
     auto workerMainloop = [this]() {
-      while (true)
-      {
-        std::unique_lock<std::mutex> lk(m_mutex);
-        m_cv.wait(lk, [this]() -> bool { return m_terminated.load() || !m_jobs.empty(); });
+        while (true) {
+            std::unique_lock<std::mutex> lk(m_mutex);
+            m_cv.wait(lk, [this]() -> bool {
+                return m_terminated.load() || !m_jobs.empty();
+            });
 
-        while (!m_jobs.empty())
-        {
-          auto job = std::move(m_jobs.front());
-          m_jobs.pop();
-          lk.unlock();
+            while (!m_jobs.empty()) {
+                auto job = std::move(m_jobs.front());
+                m_jobs.pop();
+                lk.unlock();
 
-          auto shouldReschedule = job();
+                auto shouldReschedule = job();
 
-          lk.lock();
-          if (shouldReschedule)
-          {
-            m_jobs.emplace(std::move(job));
-            m_cv.notify_one();
-          }
+                lk.lock();
+                if (shouldReschedule) {
+                    m_jobs.emplace(std::move(job));
+                    m_cv.notify_one();
+                }
+            }
+
+            if (m_terminated.load()) {
+                break;
+            }
         }
-
-        if (m_terminated.load())
-        {
-          break;
-        }
-      }
     };
 
     m_workers.reserve(workers);
-    for (size_t cpt = 0; cpt < workers; cpt++)
-    {
-      m_workers.emplace_back(std::thread(workerMainloop));
+    for (size_t cpt = 0; cpt < workers; cpt++) {
+        m_workers.emplace_back(std::thread(workerMainloop));
     }
-  }
+}
 
-  PoolWorker::~PoolWorker()
-  {
-    if (!m_workers.empty())
-    {
-      {
-        std::unique_lock<std::mutex> lk(m_mutex);
-        m_terminated.store(true);
-        m_cv.notify_all();
-      }
+PoolWorker::~PoolWorker()
+{
+    if (!m_workers.empty()) {
+        {
+            std::unique_lock<std::mutex> lk(m_mutex);
+            m_terminated.store(true);
+            m_cv.notify_all();
+        }
 
-      for (auto& th : m_workers)
-      {
-        th.join();
-      }
+        for (auto& th : m_workers) {
+            th.join();
+        }
     }
-  }
+}
 
-  void PoolWorker::addJob(Job&& work)
-  {
+void PoolWorker::addJob(Job&& work)
+{
     std::unique_lock<std::mutex> lk(m_mutex);
 
-    if (m_workers.empty())
-    {
-      // No workers, run work unit synchronously.
-      work();
+    if (m_workers.empty()) {
+        // No workers, run work unit synchronously.
+        work();
+    } else {
+        // Got workers, schedule.
+        m_jobs.emplace(work);
+        m_cv.notify_one();
     }
-    else
-    {
-      // Got workers, schedule.
-      m_jobs.emplace(work);
-      m_cv.notify_one();
-    }
-  }
+}
 
 } // namespace fty::messagebus::utils

--- a/utils/tests/Dispatcher.cpp
+++ b/utils/tests/Dispatcher.cpp
@@ -17,9 +17,8 @@
     =========================================================================
 */
 
-#include <fty/messagebus/utils/MsgBusDispatcher.hpp>
 #include <catch2/catch.hpp>
-
+#include <fty/messagebus/utils/MsgBusDispatcher.hpp>
 #include <iostream>
 #include <set>
 
@@ -32,22 +31,25 @@ TEST_CASE("Dispatcher")
         // Four-function calculator test.
         std::cerr << "  - calculator: ";
 
-        using CalculatorDispatcher = Dispatcher<std::string, std::function<int(int, int)>, std::function<int(const std::string&, int, int)>>;
+        using CalculatorDispatcher =
+            Dispatcher<std::string, std::function<int(int, int)>, std::function<int(const std::string&, int, int)>>;
+        // clang-format off
         CalculatorDispatcher::Map calculatorMap {
             { "+", [](int a, int b) -> int { return a + b; }},
             { "-", [](int a, int b) -> int { return a - b; }},
             { "*", [](int a, int b) -> int { return a * b; }},
             { "/", [](int a, int b) -> int { return a / b; }},
-        } ;
+        };
+        // clang-format on
 
         CalculatorDispatcher calculator(calculatorMap);
 
         for (int b = 1; b < 10; b++) {
             for (int a = 1; a < 10; a++) {
-                REQUIRE(calculator("+", a, b) == (a+b));
-                REQUIRE(calculator("-", a, b) == (a-b));
-                REQUIRE(calculator("*", a, b) == (a*b));
-                REQUIRE(calculator("/", a, b) == (a/b));
+                REQUIRE(calculator("+", a, b) == (a + b));
+                REQUIRE(calculator("-", a, b) == (a - b));
+                REQUIRE(calculator("*", a, b) == (a * b));
+                REQUIRE(calculator("/", a, b) == (a / b));
             }
         }
 
@@ -62,14 +64,17 @@ TEST_CASE("Dispatcher")
         std::cerr << "  - translator: ";
 
         using TranslatorDispatcher = Dispatcher<std::string, std::function<std::string()>, std::function<std::string(const std::string&)>>;
+        // clang-format off
         TranslatorDispatcher::Map translatorMap {
             { "hello", []() -> std::string { return "bonjour"; }},
             { "goodbye", []() -> std::string { return "au revoir"; }},
-        } ;
+        };
+        // clang-format on
 
-        TranslatorDispatcher translator(translatorMap,
-            [](const std::string& word) { return "unknown word " + word; }
-        );
+
+        TranslatorDispatcher translator(translatorMap, [](const std::string& word) {
+            return "unknown word " + word;
+        });
 
         REQUIRE(translator("hello") == "bonjour");
         REQUIRE(translator("goodbye") == "au revoir");

--- a/utils/tests/PoolWorker.cpp
+++ b/utils/tests/PoolWorker.cpp
@@ -21,7 +21,6 @@
 
 #include <catch2/catch.hpp>
 #include <fty/messagebus/utils/MsgBusPoolWorker.hpp>
-
 #include <iostream>
 #include <numeric>
 #include <set>
@@ -30,146 +29,136 @@ using namespace fty::messagebus::utils;
 
 uint64_t collatz(uint64_t i)
 {
-  uint64_t n;
-  for (n = 0; i > 1; n++)
-  {
-    if (i % 2)
-    {
-      i = 3 * i + 1;
+    uint64_t n;
+    for (n = 0; i > 1; n++) {
+        if (i % 2) {
+            i = 3 * i + 1;
+        } else {
+            i = i / 2;
+        }
     }
-    else
-    {
-      i = i / 2;
-    }
-  }
-  return n;
+    return n;
 }
 
 int summation(std::vector<uint64_t> data)
 {
-  return std::accumulate(data.begin(), data.end(), 0);
+    return std::accumulate(data.begin(), data.end(), 0);
 }
 
 TEST_CASE("Pool worker")
 {
-  std::cerr << " * MsgBusPoolWorker: " << std::endl;
-  constexpr size_t NB_WORKERS = 16;
-  constexpr size_t NB_JOBS = 8 * 1024;
+    std::cerr << " * MsgBusPoolWorker: " << std::endl;
+    constexpr size_t NB_WORKERS = 16;
+    constexpr size_t NB_JOBS    = 8 * 1024;
 
-  // Job offloading test.
-  {
-    for (size_t nWorkers = 0; nWorkers < NB_WORKERS; nWorkers = nWorkers * 2 + 1)
+    // Job offloading test.
     {
-      std::cerr << "  - Array initialization with PoolWorker(" << nWorkers << "): ";
+        for (size_t nWorkers = 0; nWorkers < NB_WORKERS; nWorkers = nWorkers * 2 + 1) {
+            std::cerr << "  - Array initialization with PoolWorker(" << nWorkers << "): ";
 
-      std::vector<std::atomic_uint_fast32_t> results(NB_JOBS);
-      {
-        PoolWorker pool(nWorkers);
-        for (size_t i = 0; i < NB_JOBS; i++)
-        {
-          pool.offload([&results](size_t index) { results[index].store(index); }, i);
+            std::vector<std::atomic_uint_fast32_t> results(NB_JOBS);
+            {
+                PoolWorker pool(nWorkers);
+                for (size_t i = 0; i < NB_JOBS; i++) {
+                    pool.offload(
+                        [&results](size_t index) {
+                            results[index].store(index);
+                        },
+                        i);
+                }
+            }
+
+            for (size_t i = 0; i < NB_JOBS; i++) {
+                assert(results[i].load() == i);
+            }
+
+            std::cerr << "OK" << std::endl;
         }
-      }
-
-      for (size_t i = 0; i < NB_JOBS; i++)
-      {
-        assert(results[i].load() == i);
-      }
-
-      std::cerr << "OK" << std::endl;
-    }
-  }
-
-  // Job queueing test.
-  {
-    std::array<uint64_t, NB_JOBS> collatzExpectedResults;
-    for (size_t i = 0; i < NB_JOBS; i++)
-    {
-      collatzExpectedResults[i] = collatz(i);
     }
 
-    for (size_t nWorkers = 0; nWorkers < NB_WORKERS; nWorkers = nWorkers * 2 + 1)
+    // Job queueing test.
     {
-      std::cerr << "  - Collatz sequence with PoolWorker(" << nWorkers << "): ";
+        std::array<uint64_t, NB_JOBS> collatzExpectedResults;
+        for (size_t i = 0; i < NB_JOBS; i++) {
+            collatzExpectedResults[i] = collatz(i);
+        }
 
-      PoolWorker pool(nWorkers);
-      std::array<std::future<uint64_t>, NB_JOBS> futuresArray;
-      for (uint64_t i = 0; i < NB_JOBS; i++)
-      {
-        futuresArray[i] = pool.queue(collatz, i);
-      }
+        for (size_t nWorkers = 0; nWorkers < NB_WORKERS; nWorkers = nWorkers * 2 + 1) {
+            std::cerr << "  - Collatz sequence with PoolWorker(" << nWorkers << "): ";
 
-      for (size_t i = 0; i < NB_JOBS; i++)
-      {
-        assert(futuresArray[i].get() == collatzExpectedResults[i]);
-      }
-
-      std::cerr << "OK" << std::endl;
-    }
-  }
-
-  // Job scheduling test.
-  {
-    for (size_t nWorkers = 1; nWorkers < NB_WORKERS; nWorkers = nWorkers * 2 + 1)
-    {
-      std::cerr << "  - Integer enumeration with PoolWorker(" << nWorkers << "): ";
-
-      std::array<std::promise<uint64_t>, NB_JOBS> promisesArray;
-      std::array<std::shared_future<uint64_t>, NB_JOBS> futuresArray;
-      {
-        PoolWorker pool(nWorkers);
-        for (uint64_t i = 0; i < NB_JOBS; i++)
-        {
-          futuresArray[i] = std::shared_future(promisesArray[i].get_future());
-
-          pool.schedule([&promisesArray](uint64_t value) {
-            uint64_t next_value_1 = value * 2;
-            uint64_t next_value_2 = value * 2 + 1;
-
-            if (next_value_1 <= NB_JOBS)
-            {
-              promisesArray[next_value_1 - 1].set_value(next_value_1);
+            PoolWorker                                 pool(nWorkers);
+            std::array<std::future<uint64_t>, NB_JOBS> futuresArray;
+            for (uint64_t i = 0; i < NB_JOBS; i++) {
+                futuresArray[i] = pool.queue(collatz, i);
             }
-            if (next_value_2 <= NB_JOBS)
-            {
-              promisesArray[next_value_2 - 1].set_value(next_value_2);
+
+            for (size_t i = 0; i < NB_JOBS; i++) {
+                assert(futuresArray[i].get() == collatzExpectedResults[i]);
             }
-          },
+
+            std::cerr << "OK" << std::endl;
+        }
+    }
+
+    // Job scheduling test.
+    {
+        for (size_t nWorkers = 1; nWorkers < NB_WORKERS; nWorkers = nWorkers * 2 + 1) {
+            std::cerr << "  - Integer enumeration with PoolWorker(" << nWorkers << "): ";
+
+            std::array<std::promise<uint64_t>, NB_JOBS>       promisesArray;
+            std::array<std::shared_future<uint64_t>, NB_JOBS> futuresArray;
+            {
+                PoolWorker pool(nWorkers);
+                for (uint64_t i = 0; i < NB_JOBS; i++) {
+                    futuresArray[i] = std::shared_future(promisesArray[i].get_future());
+
+                    pool.schedule(
+                        [&promisesArray](uint64_t value) {
+                            uint64_t next_value_1 = value * 2;
+                            uint64_t next_value_2 = value * 2 + 1;
+
+                            if (next_value_1 <= NB_JOBS) {
+                                promisesArray[next_value_1 - 1].set_value(next_value_1);
+                            }
+                            if (next_value_2 <= NB_JOBS) {
+                                promisesArray[next_value_2 - 1].set_value(next_value_2);
+                            }
+                        },
                         futuresArray[i]);
+                }
+                promisesArray[0].set_value(1);
+            }
+
+            for (size_t i = 0; i < NB_JOBS; i++) {
+                auto a = futuresArray[i].get();
+                assert(a == i + 1);
+            }
+
+            std::cerr << "OK" << std::endl;
         }
-        promisesArray[0].set_value(1);
-      }
-
-      for (size_t i = 0; i < NB_JOBS; i++)
-      {
-        auto a = futuresArray[i].get();
-        assert(a == i + 1);
-      }
-
-      std::cerr << "OK" << std::endl;
     }
-  }
 
-  // Job scheduling test with apply.
-  {
-    std::cerr << "  - Schedule with apply: ";
-    std::atomic_int result;
-
+    // Job scheduling test with apply.
     {
-      PoolWorker pool(1);
-      auto promise = std::promise<std::tuple<int, int>>();
-      auto future = std::shared_future(promise.get_future());
+        std::cerr << "  - Schedule with apply: ";
+        std::atomic_int result;
 
-      pool.scheduleWithApply([&result](int a, int b) {
-        result = a + b;
-      },
-                             future);
+        {
+            PoolWorker pool(1);
+            auto       promise = std::promise<std::tuple<int, int>>();
+            auto       future  = std::shared_future(promise.get_future());
 
-      promise.set_value({2, 3});
+            pool.scheduleWithApply(
+                [&result](int a, int b) {
+                    result = a + b;
+                },
+                future);
+
+            promise.set_value({2, 3});
+        }
+
+        assert(result.load() == 5);
+
+        std::cerr << "OK" << std::endl;
     }
-
-    assert(result.load() == 5);
-
-    std::cerr << "OK" << std::endl;
-  }
 }


### PR DESCRIPTION
1) Uses of non class enums are dangerous.
2) Using expected with enums as string are very weird.
3) Code style updated as other projects in fty have.

This not necessary PR... close it if you are don't want it. :)